### PR TITLE
feat: expose network ACL and IP allowlist inputs across GenAI and Foundry resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ Description: Configuration object for the Azure AI Foundry deployment (hub, proj
   - `allow_project_management` - (Optional) Whether project management is allowed from the hub. Default is true.
   - `create_ai_agent_service` - (Optional) Whether to create the AI Agent service in the hub. Default is false.
   - `private_dns_zone_resource_ids` - (Optional) List of private DNS zone resource IDs for hub endpoints. Default is [].
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the hub account. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+  - `network_acls` - (Optional) Network access control list applied to the hub account. Default is null, which allows traffic from all networks. The rules only take effect when `public_network_access_enabled` is true.
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+    - `bypass` - (Optional) Set to "AzureServices" to let trusted Azure services bypass the rules. Default is null.
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
+    - `virtual_network_rules` - (Optional) List of subnets allowed inbound access. Default is [].
+      - `subnet_resource_id` - The resource ID of the subnet to allow.
+      - `ignore_missing_vnet_service_endpoint` - (Optional) Whether to ignore a missing virtual network service endpoint on the subnet. Default is false.
   - `sku` - (Optional) The SKU for the hub. Default is "S0".
   - `tags` - (Optional) Map of tags to assign to the AI Foundry hub.
   - `role_assignments` - (Optional) Map of role assignments on the hub. The map key is deliberately arbitrary to avoid plan-time unknown key issues.
@@ -332,6 +340,10 @@ Description: Configuration object for the Azure AI Foundry deployment (hub, proj
     - `semantic_search_sku` - (Optional) Semantic search SKU. Default is "standard".
     - `semantic_search_enabled` - (Optional) Whether semantic search is enabled. Default is false.
     - `hosting_mode` - (Optional) Hosting mode. Default is "default".
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the search service. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_rule_set` - (Optional) Inbound network rules applied to the search service. Only takes effect when public network access is enabled.
+      - `bypass` - (Optional) Whether trusted Azure services may bypass the rules. Possible values are "None" and "AzureServices". Default is "None".
+      - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
     - `tags` - (Optional) Map of tags for the service.
     - `role_assignments` - (Optional) Map of role assignments on the service.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
@@ -370,6 +382,11 @@ Description: Configuration object for the Azure AI Foundry deployment (hub, proj
     - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
     - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
     - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+    - `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+    - `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+    - `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+    - `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+      - `subnet_id` - The resource ID of the subnet to allow.
     - `analytical_storage_config` - (Optional) Analytical storage configuration. Default is null.
       - `schema_type` - Schema type for analytical storage.
     - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -421,6 +438,12 @@ Description: Configuration object for the Azure AI Foundry deployment (hub, proj
         - `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.
     - `sku` - (Optional) Vault SKU. Default is "standard".
     - `tenant_id` - (Optional) Tenant ID for the Key Vault.
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the Key Vault. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_acls` - (Optional) Network access control list applied to the Key Vault. Defaults to allowing all networks with an `AzureServices` bypass.
+      - `bypass` - (Optional) Traffic permitted to bypass the rules. Possible values are "AzureServices" and "None". Default is "AzureServices".
+      - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+      - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed access. Default is [].
+      - `virtual_network_subnet_ids` - (Optional) List of subnet resource IDs allowed access. Default is [].
     - `role_assignments` - (Optional) Map of role assignments on the vault.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
       - `principal_id` - Principal ID for the assignment.
@@ -456,6 +479,15 @@ Description: Configuration object for the Azure AI Foundry deployment (hub, proj
       - `private_endpoints_manage_dns_zone_group` - (Optional) Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy. Default is true.
     - `access_tier` - (Optional) Access tier for the account. Default is "Hot".
     - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the storage account. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_rules` - (Optional) Storage account firewall configuration. Default is null, in which case the upstream module applies deny-by-default with an `AzureServices` bypass, matching the private endpoint topology this module deploys.
+      - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+      - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+      - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+      - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+      - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+        - `endpoint_resource_id` - The resource ID granted access.
+        - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
     - `role_assignments` - (Optional) Map of role assignments on the storage account.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
       - `principal_id` - Principal ID for the assignment.
@@ -497,8 +529,18 @@ object({
       #network_injections is statically set to vnet/subnet created in the module.
       private_dns_zone_resource_ids           = optional(list(string), [])
       private_endpoints_manage_dns_zone_group = optional(bool, true)
-      sku                                     = optional(string, "S0")
-      tags                                    = optional(map(string))
+      public_network_access_enabled           = optional(bool, null)
+      network_acls = optional(object({
+        default_action = optional(string, "Allow")
+        bypass         = optional(string, null)
+        ip_rules       = optional(list(string), [])
+        virtual_network_rules = optional(list(object({
+          subnet_resource_id                   = string
+          ignore_missing_vnet_service_endpoint = optional(bool, false)
+        })), [])
+      }), null)
+      sku  = optional(string, "S0")
+      tags = optional(map(string))
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -571,14 +613,19 @@ object({
         event_hub_name                           = optional(string, null)
         marketplace_partner_resource_id          = optional(string, null)
       })), {})
-      sku                          = optional(string, "standard")
-      local_authentication_enabled = optional(bool, true)
-      partition_count              = optional(number, 1)
-      replica_count                = optional(number, 2)
-      semantic_search_sku          = optional(string, "standard")
-      semantic_search_enabled      = optional(bool, false)
-      hosting_mode                 = optional(string, "default")
-      tags                         = optional(map(string))
+      sku                           = optional(string, "standard")
+      local_authentication_enabled  = optional(bool, true)
+      partition_count               = optional(number, 1)
+      replica_count                 = optional(number, 2)
+      semantic_search_sku           = optional(string, "standard")
+      semantic_search_enabled       = optional(bool, false)
+      hosting_mode                  = optional(string, "default")
+      public_network_access_enabled = optional(bool, null)
+      network_rule_set = optional(object({
+        bypass   = optional(string, "None")
+        ip_rules = optional(list(string), [])
+      }), {})
+      tags = optional(map(string))
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -620,6 +667,18 @@ object({
       local_authentication_disabled    = optional(bool, true)
       partition_merge_enabled          = optional(bool, false)
       multiple_write_locations_enabled = optional(bool, false)
+      # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+      ip_range_filter = optional(set(string), [
+        "168.125.123.255",
+        "170.0.0.0/24",
+        "0.0.0.0",
+        "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+      ])
+      network_acl_bypass_for_azure_services = optional(bool, true)
+      network_acl_bypass_resource_ids       = optional(set(string), [])
+      virtual_network_rules = optional(set(object({
+        subnet_id = string
+      })), [])
       analytical_storage_config = optional(object({
         schema_type = string
       }), null)
@@ -678,8 +737,15 @@ object({
         event_hub_name                           = optional(string, null)
         marketplace_partner_resource_id          = optional(string, null)
       })), {})
-      sku       = optional(string, "standard")
-      tenant_id = optional(string)
+      sku                           = optional(string, "standard")
+      tenant_id                     = optional(string)
+      public_network_access_enabled = optional(bool, null)
+      network_acls = optional(object({
+        bypass                     = optional(string, "AzureServices")
+        default_action             = optional(string, "Allow")
+        ip_rules                   = optional(list(string), [])
+        virtual_network_subnet_ids = optional(list(string), [])
+      }), {})
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -720,8 +786,19 @@ object({
           type = "blob"
         }
       })
-      access_tier               = optional(string, "Hot")
-      shared_access_key_enabled = optional(bool, false)
+      access_tier                   = optional(string, "Hot")
+      shared_access_key_enabled     = optional(bool, false)
+      public_network_access_enabled = optional(bool, null)
+      network_rules = optional(object({
+        bypass                     = optional(set(string), ["AzureServices"])
+        default_action             = optional(string, "Deny")
+        ip_rules                   = optional(set(string), [])
+        virtual_network_subnet_ids = optional(set(string), [])
+        private_link_access = optional(list(object({
+          endpoint_resource_id = string
+          endpoint_tenant_id   = optional(string)
+        })), null)
+      }), null)
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -1587,6 +1664,7 @@ Description: Configuration object for the Azure App Configuration service to be 
 - `deploy` - (Optional) Whether to deploy the App Configuration store. Default is true.
 - `name` - (Optional) The name of the App Configuration store. If not provided, a name will be generated.
 - `local_auth_enabled` - (Optional) Whether local authentication is enabled. Default is false.
+- `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false. Azure App Configuration exposes no IP-based network ACLs, so access is restricted through the private endpoint this module creates.
 - `purge_protection_enabled` - (Optional) Whether purge protection is enabled. Default is true.
 - `sku` - (Optional) The SKU of the App Configuration store. Default is "standard".
 - `soft_delete_retention_in_days` - (Optional) The retention period in days for soft delete. Default is 7.
@@ -1624,6 +1702,7 @@ object({
     deploy                        = optional(bool, true)
     name                          = optional(string)
     local_auth_enabled            = optional(bool, false)
+    public_network_access_enabled = optional(bool, false)
     purge_protection_enabled      = optional(bool, true)
     sku                           = optional(string, "standard")
     soft_delete_retention_in_days = optional(number, 7)
@@ -1665,6 +1744,12 @@ Description: Configuration object for the Azure Container Registry to be created
 - `sku` - (Optional) The SKU of the Container Registry. Default is "Premium".
 - `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled. Default is true.
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
+- `network_rule_bypass_option` - (Optional) Whether trusted Azure services can access a network restricted Container Registry. Possible values are "None" and "AzureServices". Default is "None".
+- `network_rule_set` - (Optional) IP allowlist applied to the Container Registry. Requires the Premium SKU. Default is null, which leaves the registry firewall unconfigured.
+  - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+  - `ip_rule` - (Optional) List of allowed IP ranges. Default is [].
+    - `action` - (Optional) The rule action. Azure only permits "Allow". Default is "Allow".
+    - `ip_range` - The CIDR block allowed inbound access.
 - `enable_diagnostic_settings` - (Optional) Whether diagnostic settings are enabled. Default is true.
 - `diagnostic_settings` - (Optional) Map of diagnostic settings configurations for the Container Registry. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `name` - (Optional) The name of the diagnostic setting.
@@ -1697,7 +1782,15 @@ object({
     sku                           = optional(string, "Premium")
     zone_redundancy_enabled       = optional(bool, true)
     public_network_access_enabled = optional(bool, false)
-    enable_diagnostic_settings    = optional(bool, true)
+    network_rule_bypass_option    = optional(string, "None")
+    network_rule_set = optional(object({
+      default_action = optional(string, "Deny")
+      ip_rule = optional(list(object({
+        action   = optional(string, "Allow")
+        ip_range = string
+      })), [])
+    }), null)
+    enable_diagnostic_settings = optional(bool, true)
     diagnostic_settings = optional(map(object({
       name                                     = optional(string, null)
       log_categories                           = optional(set(string), [])
@@ -1754,6 +1847,11 @@ Description: Configuration object for the Azure Cosmos DB account to be created 
 - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
 - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
 - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+- `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+- `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+- `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+- `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+  - `subnet_id` - The resource ID of the subnet to allow.
 - `analytical_storage_config` - (Optional) Analytical storage configuration.
   - `schema_type` - The schema type for analytical storage.
 - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -1808,6 +1906,18 @@ object({
     local_authentication_disabled    = optional(bool, true)
     partition_merge_enabled          = optional(bool, false)
     multiple_write_locations_enabled = optional(bool, false)
+    # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+    ip_range_filter = optional(set(string), [
+      "168.125.123.255",
+      "170.0.0.0/24",
+      "0.0.0.0",
+      "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+    ])
+    network_acl_bypass_for_azure_services = optional(bool, true)
+    network_acl_bypass_resource_ids       = optional(set(string), [])
+    virtual_network_rules = optional(set(object({
+      subnet_id = string
+    })), [])
     analytical_storage_config = optional(object({
       schema_type = string
     }), null)
@@ -1948,6 +2058,14 @@ Description: Configuration object for the Azure Storage Account to be created fo
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
+- `network_rules` - (Optional) Storage account firewall configuration. Defaults to `{}`, which denies public traffic while still allowing trusted Azure services. Set to `null` to remove all network rules, which leaves the account reachable from any public network.
+  - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+  - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+  - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+  - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+  - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+    - `endpoint_resource_id` - The resource ID granted access.
+    - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
 - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `role_definition_id_or_name` - The role definition ID or name to assign.
   - `principal_id` - The principal ID to assign the role to.
@@ -1985,6 +2103,16 @@ object({
     access_tier                   = optional(string, "Hot")
     public_network_access_enabled = optional(bool, false)
     shared_access_key_enabled     = optional(bool, true)
+    network_rules = optional(object({
+      bypass                     = optional(set(string), ["AzureServices"])
+      default_action             = optional(string, "Deny")
+      ip_rules                   = optional(set(string), [])
+      virtual_network_subnet_ids = optional(set(string), [])
+      private_link_access = optional(list(object({
+        endpoint_resource_id = string
+        endpoint_tenant_id   = optional(string)
+      })), null)
+    }), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -2048,6 +2176,7 @@ Description: Configuration object for the Azure AI Search service to be created 
   - `marketplace_partner_resource_id` - (Optional) Resource ID of the marketplace partner resource.
 - `sku` - (Optional) The SKU of the AI Search service. Default is "standard".
 - `local_authentication_enabled` - (Optional) Whether local authentication is enabled. Default is true.
+- `allowed_ips` - (Optional) List of IP addresses or CIDR blocks allowed to reach the AI Search service. Default is null (no IP allowlist). Only takes effect when `public_network_access_enabled` is true.
 - `network_rule_bypass_option` - (Optional) Whether trusted Azure services can access a network restricted AI Search service. Possible values are "None" and "AzureServices". Default is "None".
 - `partition_count` - (Optional) The number of partitions for the search service. Default is 1.
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
@@ -2086,6 +2215,7 @@ object({
     })), {})
     sku                           = optional(string, "standard")
     local_authentication_enabled  = optional(bool, true)
+    allowed_ips                   = optional(list(string), null)
     network_rule_bypass_option    = optional(string, "None")
     partition_count               = optional(number, 1)
     public_network_access_enabled = optional(bool, false)
@@ -2511,7 +2641,7 @@ Version: 0.4.1
 
 Source: Azure/avm-ptn-aiml-ai-foundry/azurerm
 
-Version: 0.11.2
+Version: 0.11.3
 
 ### <a name="module_fw_pip"></a> [fw\_pip](#module\_fw\_pip)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -255,11 +255,18 @@ module "test" {
     }
   }
   genai_storage_account_definition = {
+    # Rules are stored but only enforced once public_network_access_enabled is true.
+    network_rules = {
+      bypass         = ["AzureServices"]
+      default_action = "Deny"
+      ip_rules       = [data.http.ip.response_body]
+    }
   }
   jumpvm_definition = {
     sku = module.vm_sku.sku
   }
   ks_ai_search_definition = {
+    allowed_ips                = [data.http.ip.response_body]
     enable_diagnostic_settings = false
   }
   private_dns_zones = {

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -248,11 +248,18 @@ module "test" {
     }
   }
   genai_storage_account_definition = {
+    # Rules are stored but only enforced once public_network_access_enabled is true.
+    network_rules = {
+      bypass         = ["AzureServices"]
+      default_action = "Deny"
+      ip_rules       = [data.http.ip.response_body]
+    }
   }
   jumpvm_definition = {
     sku = module.vm_sku.sku
   }
   ks_ai_search_definition = {
+    allowed_ips                = [data.http.ip.response_body]
     enable_diagnostic_settings = false
   }
   private_dns_zones = {

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -1,6 +1,6 @@
 module "foundry_ptn" {
   source  = "Azure/avm-ptn-aiml-ai-foundry/azurerm"
-  version = "0.11.2"
+  version = "0.11.3"
 
   #configure the base resource
   base_name                  = coalesce(var.name_prefix, "foundry")

--- a/main.genai_services.tf
+++ b/main.genai_services.tf
@@ -77,19 +77,15 @@ module "cosmosdb" {
     max_interval_in_seconds = var.genai_cosmosdb_definition.consistency_policy.max_interval_in_seconds
     max_staleness_prefix    = var.genai_cosmosdb_definition.consistency_policy.max_staleness_prefix
   }
-  cors_rule           = var.genai_cosmosdb_definition.cors_rule
-  diagnostic_settings = local.genai_cosmosdb_diagnostic_settings
-  enable_telemetry    = var.enable_telemetry
-  geo_locations       = local.genai_cosmosdb_secondary_regions
-  ip_range_filter = [
-    "168.125.123.255",
-    "170.0.0.0/24",                                                                 #TODO: check 0.0.0.0 for validity
-    "0.0.0.0",                                                                      #Accept connections from within public Azure datacenters. https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-the-azure-portal
-    "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26" #Allow access from the Azure portal. https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-global-azure-datacenters-or-other-sources-within-azure
-  ]
+  cors_rule                             = var.genai_cosmosdb_definition.cors_rule
+  diagnostic_settings                   = local.genai_cosmosdb_diagnostic_settings
+  enable_telemetry                      = var.enable_telemetry
+  geo_locations                         = local.genai_cosmosdb_secondary_regions
+  ip_range_filter                       = var.genai_cosmosdb_definition.ip_range_filter
   local_authentication_disabled         = var.genai_cosmosdb_definition.local_authentication_disabled
   multiple_write_locations_enabled      = var.genai_cosmosdb_definition.multiple_write_locations_enabled
-  network_acl_bypass_for_azure_services = true
+  network_acl_bypass_for_azure_services = var.genai_cosmosdb_definition.network_acl_bypass_for_azure_services
+  network_acl_bypass_resource_ids       = var.genai_cosmosdb_definition.network_acl_bypass_resource_ids
   partition_merge_enabled               = var.genai_cosmosdb_definition.partition_merge_enabled
   private_endpoints = {
     "sql" = {
@@ -100,6 +96,7 @@ module "cosmosdb" {
   }
   public_network_access_enabled = var.genai_cosmosdb_definition.public_network_access_enabled
   tags                          = merge(local.tags, var.genai_cosmosdb_definition.tags != null ? var.genai_cosmosdb_definition.tags : {})
+  virtual_network_rules         = var.genai_cosmosdb_definition.virtual_network_rules
 
   depends_on = [module.private_dns_zones, module.hub_vnet_peering]
 }
@@ -123,6 +120,7 @@ module "storage_account" {
   diagnostic_settings_storage_account = local.genai_storage_account_diagnostic_settings
   enable_telemetry                    = var.enable_telemetry
   local_user_enabled                  = false
+  network_rules                       = var.genai_storage_account_definition.network_rules
   private_endpoints = {
     for endpoint in var.genai_storage_account_definition.endpoint_types :
     endpoint => {
@@ -145,11 +143,13 @@ module "containerregistry" {
   version = "0.5.0"
   count   = var.genai_container_registry_definition.deploy ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
-  name                = local.genai_container_registry_name
-  resource_group_name = azurerm_resource_group.this.name
-  diagnostic_settings = local.genai_container_registry_diagnostic_settings
-  enable_telemetry    = var.enable_telemetry
+  location                   = azurerm_resource_group.this.location
+  name                       = local.genai_container_registry_name
+  resource_group_name        = azurerm_resource_group.this.name
+  diagnostic_settings        = local.genai_container_registry_diagnostic_settings
+  enable_telemetry           = var.enable_telemetry
+  network_rule_bypass_option = var.genai_container_registry_definition.network_rule_bypass_option
+  network_rule_set           = var.genai_container_registry_definition.network_rule_set
   private_endpoints = {
     container_registry = {
       private_dns_zone_resource_ids = var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? null : (!var.flag_platform_landing_zone ? [module.private_dns_zones.container_registry_zone.resource_id] : [local.private_dns_zones_existing.container_registry_zone.resource_id])
@@ -182,8 +182,9 @@ module "app_configuration" {
       subnet_resource_id            = local.subnet_ids["PrivateEndpointSubnet"]
     }
   }
-  role_assignments           = local.genai_app_configuration_role_assignments
-  sku                        = var.genai_app_configuration_definition.sku
-  soft_delete_retention_days = var.genai_app_configuration_definition.soft_delete_retention_in_days
-  tags                       = merge(local.tags, var.genai_app_configuration_definition.tags != null ? var.genai_app_configuration_definition.tags : {})
+  public_network_access_enabled = var.genai_app_configuration_definition.public_network_access_enabled
+  role_assignments              = local.genai_app_configuration_role_assignments
+  sku                           = var.genai_app_configuration_definition.sku
+  soft_delete_retention_days    = var.genai_app_configuration_definition.soft_delete_retention_in_days
+  tags                          = merge(local.tags, var.genai_app_configuration_definition.tags != null ? var.genai_app_configuration_definition.tags : {})
 }

--- a/main.knowledge_sources.tf
+++ b/main.knowledge_sources.tf
@@ -6,6 +6,7 @@ module "search_service" {
   location                     = azurerm_resource_group.this.location
   name                         = local.ks_ai_search_name
   resource_group_name          = azurerm_resource_group.this.name
+  allowed_ips                  = var.ks_ai_search_definition.allowed_ips
   diagnostic_settings          = local.ks_ai_search_diagnostic_settings
   enable_telemetry             = var.enable_telemetry # see variables.tf
   local_authentication_enabled = var.ks_ai_search_definition.local_authentication_enabled

--- a/variables.foundry.tf
+++ b/variables.foundry.tf
@@ -26,8 +26,18 @@ variable "ai_foundry_definition" {
       #network_injections is statically set to vnet/subnet created in the module.
       private_dns_zone_resource_ids           = optional(list(string), [])
       private_endpoints_manage_dns_zone_group = optional(bool, true)
-      sku                                     = optional(string, "S0")
-      tags                                    = optional(map(string))
+      public_network_access_enabled           = optional(bool, null)
+      network_acls = optional(object({
+        default_action = optional(string, "Allow")
+        bypass         = optional(string, null)
+        ip_rules       = optional(list(string), [])
+        virtual_network_rules = optional(list(object({
+          subnet_resource_id                   = string
+          ignore_missing_vnet_service_endpoint = optional(bool, false)
+        })), [])
+      }), null)
+      sku  = optional(string, "S0")
+      tags = optional(map(string))
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -100,14 +110,19 @@ variable "ai_foundry_definition" {
         event_hub_name                           = optional(string, null)
         marketplace_partner_resource_id          = optional(string, null)
       })), {})
-      sku                          = optional(string, "standard")
-      local_authentication_enabled = optional(bool, true)
-      partition_count              = optional(number, 1)
-      replica_count                = optional(number, 2)
-      semantic_search_sku          = optional(string, "standard")
-      semantic_search_enabled      = optional(bool, false)
-      hosting_mode                 = optional(string, "default")
-      tags                         = optional(map(string))
+      sku                           = optional(string, "standard")
+      local_authentication_enabled  = optional(bool, true)
+      partition_count               = optional(number, 1)
+      replica_count                 = optional(number, 2)
+      semantic_search_sku           = optional(string, "standard")
+      semantic_search_enabled       = optional(bool, false)
+      hosting_mode                  = optional(string, "default")
+      public_network_access_enabled = optional(bool, null)
+      network_rule_set = optional(object({
+        bypass   = optional(string, "None")
+        ip_rules = optional(list(string), [])
+      }), {})
+      tags = optional(map(string))
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -149,6 +164,18 @@ variable "ai_foundry_definition" {
       local_authentication_disabled    = optional(bool, true)
       partition_merge_enabled          = optional(bool, false)
       multiple_write_locations_enabled = optional(bool, false)
+      # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+      ip_range_filter = optional(set(string), [
+        "168.125.123.255",
+        "170.0.0.0/24",
+        "0.0.0.0",
+        "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+      ])
+      network_acl_bypass_for_azure_services = optional(bool, true)
+      network_acl_bypass_resource_ids       = optional(set(string), [])
+      virtual_network_rules = optional(set(object({
+        subnet_id = string
+      })), [])
       analytical_storage_config = optional(object({
         schema_type = string
       }), null)
@@ -207,8 +234,15 @@ variable "ai_foundry_definition" {
         event_hub_name                           = optional(string, null)
         marketplace_partner_resource_id          = optional(string, null)
       })), {})
-      sku       = optional(string, "standard")
-      tenant_id = optional(string)
+      sku                           = optional(string, "standard")
+      tenant_id                     = optional(string)
+      public_network_access_enabled = optional(bool, null)
+      network_acls = optional(object({
+        bypass                     = optional(string, "AzureServices")
+        default_action             = optional(string, "Allow")
+        ip_rules                   = optional(list(string), [])
+        virtual_network_subnet_ids = optional(list(string), [])
+      }), {})
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -249,8 +283,19 @@ variable "ai_foundry_definition" {
           type = "blob"
         }
       })
-      access_tier               = optional(string, "Hot")
-      shared_access_key_enabled = optional(bool, false)
+      access_tier                   = optional(string, "Hot")
+      shared_access_key_enabled     = optional(bool, false)
+      public_network_access_enabled = optional(bool, null)
+      network_rules = optional(object({
+        bypass                     = optional(set(string), ["AzureServices"])
+        default_action             = optional(string, "Deny")
+        ip_rules                   = optional(set(string), [])
+        virtual_network_subnet_ids = optional(set(string), [])
+        private_link_access = optional(list(object({
+          endpoint_resource_id = string
+          endpoint_tenant_id   = optional(string)
+        })), null)
+      }), null)
       role_assignments = optional(map(object({
         role_definition_id_or_name             = string
         principal_id                           = string
@@ -288,6 +333,14 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
   - `allow_project_management` - (Optional) Whether project management is allowed from the hub. Default is true.
   - `create_ai_agent_service` - (Optional) Whether to create the AI Agent service in the hub. Default is false.
   - `private_dns_zone_resource_ids` - (Optional) List of private DNS zone resource IDs for hub endpoints. Default is [].
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the hub account. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+  - `network_acls` - (Optional) Network access control list applied to the hub account. Default is null, which allows traffic from all networks. The rules only take effect when `public_network_access_enabled` is true.
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+    - `bypass` - (Optional) Set to "AzureServices" to let trusted Azure services bypass the rules. Default is null.
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
+    - `virtual_network_rules` - (Optional) List of subnets allowed inbound access. Default is [].
+      - `subnet_resource_id` - The resource ID of the subnet to allow.
+      - `ignore_missing_vnet_service_endpoint` - (Optional) Whether to ignore a missing virtual network service endpoint on the subnet. Default is false.
   - `sku` - (Optional) The SKU for the hub. Default is "S0".
   - `tags` - (Optional) Map of tags to assign to the AI Foundry hub.
   - `role_assignments` - (Optional) Map of role assignments on the hub. The map key is deliberately arbitrary to avoid plan-time unknown key issues.
@@ -358,6 +411,10 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
     - `semantic_search_sku` - (Optional) Semantic search SKU. Default is "standard".
     - `semantic_search_enabled` - (Optional) Whether semantic search is enabled. Default is false.
     - `hosting_mode` - (Optional) Hosting mode. Default is "default".
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the search service. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_rule_set` - (Optional) Inbound network rules applied to the search service. Only takes effect when public network access is enabled.
+      - `bypass` - (Optional) Whether trusted Azure services may bypass the rules. Possible values are "None" and "AzureServices". Default is "None".
+      - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
     - `tags` - (Optional) Map of tags for the service.
     - `role_assignments` - (Optional) Map of role assignments on the service.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
@@ -396,6 +453,11 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
     - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
     - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
     - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+    - `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+    - `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+    - `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+    - `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+      - `subnet_id` - The resource ID of the subnet to allow.
     - `analytical_storage_config` - (Optional) Analytical storage configuration. Default is null.
       - `schema_type` - Schema type for analytical storage.
     - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -447,6 +509,12 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
         - `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.
     - `sku` - (Optional) Vault SKU. Default is "standard".
     - `tenant_id` - (Optional) Tenant ID for the Key Vault.
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the Key Vault. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_acls` - (Optional) Network access control list applied to the Key Vault. Defaults to allowing all networks with an `AzureServices` bypass.
+      - `bypass` - (Optional) Traffic permitted to bypass the rules. Possible values are "AzureServices" and "None". Default is "AzureServices".
+      - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+      - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed access. Default is [].
+      - `virtual_network_subnet_ids` - (Optional) List of subnet resource IDs allowed access. Default is [].
     - `role_assignments` - (Optional) Map of role assignments on the vault.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
       - `principal_id` - Principal ID for the assignment.
@@ -482,6 +550,15 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
       - `private_endpoints_manage_dns_zone_group` - (Optional) Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy. Default is true.
     - `access_tier` - (Optional) Access tier for the account. Default is "Hot".
     - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
+    - `public_network_access_enabled` - (Optional) Overrides public network access on the storage account. Default is null, which lets the upstream module derive the value from the private endpoint configuration (public access disabled).
+    - `network_rules` - (Optional) Storage account firewall configuration. Default is null, in which case the upstream module applies deny-by-default with an `AzureServices` bypass, matching the private endpoint topology this module deploys.
+      - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+      - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+      - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+      - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+      - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+        - `endpoint_resource_id` - The resource ID granted access.
+        - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
     - `role_assignments` - (Optional) Map of role assignments on the storage account.
       - `role_definition_id_or_name` - Role definition ID or name to assign.
       - `principal_id` - Principal ID for the assignment.
@@ -495,4 +572,13 @@ Configuration object for the Azure AI Foundry deployment (hub, projects, and Bri
 
 This object supports both creating new resources and connecting to existing ones, enabling flexible deployment scenarios across the hub, projects, and dependent services.
 DESCRIPTION
+
+  validation {
+    condition     = try(var.ai_foundry_definition.ai_foundry.network_acls, null) == null ? true : contains(["Allow", "Deny"], var.ai_foundry_definition.ai_foundry.network_acls.default_action)
+    error_message = "The ai_foundry.network_acls.default_action must be one of: 'Allow', 'Deny'."
+  }
+  validation {
+    condition     = try(var.ai_foundry_definition.ai_foundry.network_acls.bypass, null) == null ? true : var.ai_foundry_definition.ai_foundry.network_acls.bypass == "AzureServices"
+    error_message = "The ai_foundry.network_acls.bypass must be 'AzureServices' or null."
+  }
 }

--- a/variables.genai_services.tf
+++ b/variables.genai_services.tf
@@ -8,6 +8,7 @@ variable "genai_app_configuration_definition" {
     deploy                        = optional(bool, true)
     name                          = optional(string)
     local_auth_enabled            = optional(bool, false)
+    public_network_access_enabled = optional(bool, false)
     purge_protection_enabled      = optional(bool, true)
     sku                           = optional(string, "standard")
     soft_delete_retention_in_days = optional(number, 7)
@@ -46,6 +47,7 @@ Configuration object for the Azure App Configuration service to be created for G
 - `deploy` - (Optional) Whether to deploy the App Configuration store. Default is true.
 - `name` - (Optional) The name of the App Configuration store. If not provided, a name will be generated.
 - `local_auth_enabled` - (Optional) Whether local authentication is enabled. Default is false.
+- `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false. Azure App Configuration exposes no IP-based network ACLs, so access is restricted through the private endpoint this module creates.
 - `purge_protection_enabled` - (Optional) Whether purge protection is enabled. Default is true.
 - `sku` - (Optional) The SKU of the App Configuration store. Default is "standard".
 - `soft_delete_retention_in_days` - (Optional) The retention period in days for soft delete. Default is 7.
@@ -83,7 +85,15 @@ variable "genai_container_registry_definition" {
     sku                           = optional(string, "Premium")
     zone_redundancy_enabled       = optional(bool, true)
     public_network_access_enabled = optional(bool, false)
-    enable_diagnostic_settings    = optional(bool, true)
+    network_rule_bypass_option    = optional(string, "None")
+    network_rule_set = optional(object({
+      default_action = optional(string, "Deny")
+      ip_rule = optional(list(object({
+        action   = optional(string, "Allow")
+        ip_range = string
+      })), [])
+    }), null)
+    enable_diagnostic_settings = optional(bool, true)
     diagnostic_settings = optional(map(object({
       name                                     = optional(string, null)
       log_categories                           = optional(set(string), [])
@@ -117,6 +127,12 @@ Configuration object for the Azure Container Registry to be created for GenAI se
 - `sku` - (Optional) The SKU of the Container Registry. Default is "Premium".
 - `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled. Default is true.
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
+- `network_rule_bypass_option` - (Optional) Whether trusted Azure services can access a network restricted Container Registry. Possible values are "None" and "AzureServices". Default is "None".
+- `network_rule_set` - (Optional) IP allowlist applied to the Container Registry. Requires the Premium SKU. Default is null, which leaves the registry firewall unconfigured.
+  - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+  - `ip_rule` - (Optional) List of allowed IP ranges. Default is [].
+    - `action` - (Optional) The rule action. Azure only permits "Allow". Default is "Allow".
+    - `ip_range` - The CIDR block allowed inbound access.
 - `enable_diagnostic_settings` - (Optional) Whether diagnostic settings are enabled. Default is true.
 - `diagnostic_settings` - (Optional) Map of diagnostic settings configurations for the Container Registry. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `name` - (Optional) The name of the diagnostic setting.
@@ -140,6 +156,15 @@ Configuration object for the Azure Container Registry to be created for GenAI se
   - `delegated_managed_identity_resource_id` - (Optional) Resource ID of the delegated managed identity.
   - `principal_type` - (Optional) Type of the principal (User, Group, ServicePrincipal).
 DESCRIPTION
+
+  validation {
+    condition     = contains(["None", "AzureServices"], var.genai_container_registry_definition.network_rule_bypass_option)
+    error_message = "The network_rule_bypass_option must be one of: 'None', 'AzureServices'."
+  }
+  validation {
+    condition     = var.genai_container_registry_definition.network_rule_set == null ? true : contains(["Allow", "Deny"], var.genai_container_registry_definition.network_rule_set.default_action)
+    error_message = "The network_rule_set.default_action must be one of: 'Allow', 'Deny'."
+  }
 }
 
 variable "genai_cosmosdb_definition" {
@@ -170,6 +195,18 @@ variable "genai_cosmosdb_definition" {
     local_authentication_disabled    = optional(bool, true)
     partition_merge_enabled          = optional(bool, false)
     multiple_write_locations_enabled = optional(bool, false)
+    # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+    ip_range_filter = optional(set(string), [
+      "168.125.123.255",
+      "170.0.0.0/24",
+      "0.0.0.0",
+      "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+    ])
+    network_acl_bypass_for_azure_services = optional(bool, true)
+    network_acl_bypass_resource_ids       = optional(set(string), [])
+    virtual_network_rules = optional(set(object({
+      subnet_id = string
+    })), [])
     analytical_storage_config = optional(object({
       schema_type = string
     }), null)
@@ -228,6 +265,11 @@ Configuration object for the Azure Cosmos DB account to be created for GenAI ser
 - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
 - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
 - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+- `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+- `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+- `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+- `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+  - `subnet_id` - The resource ID of the subnet to allow.
 - `analytical_storage_config` - (Optional) Analytical storage configuration.
   - `schema_type` - The schema type for analytical storage.
 - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -355,6 +397,16 @@ variable "genai_storage_account_definition" {
     access_tier                   = optional(string, "Hot")
     public_network_access_enabled = optional(bool, false)
     shared_access_key_enabled     = optional(bool, true)
+    network_rules = optional(object({
+      bypass                     = optional(set(string), ["AzureServices"])
+      default_action             = optional(string, "Deny")
+      ip_rules                   = optional(set(string), [])
+      virtual_network_subnet_ids = optional(set(string), [])
+      private_link_access = optional(list(object({
+        endpoint_resource_id = string
+        endpoint_tenant_id   = optional(string)
+      })), null)
+    }), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -395,6 +447,14 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
+- `network_rules` - (Optional) Storage account firewall configuration. Defaults to `{}`, which denies public traffic while still allowing trusted Azure services. Set to `null` to remove all network rules, which leaves the account reachable from any public network.
+  - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+  - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+  - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+  - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+  - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+    - `endpoint_resource_id` - The resource ID granted access.
+    - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
 - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `role_definition_id_or_name` - The role definition ID or name to assign.
   - `principal_id` - The principal ID to assign the role to.
@@ -406,4 +466,13 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
   - `principal_type` - (Optional) Type of the principal (User, Group, ServicePrincipal).
 - `tags` - (Optional) Map of tags to assign to the Storage Account.
 DESCRIPTION
+
+  validation {
+    condition     = var.genai_storage_account_definition.network_rules == null ? true : contains(["Allow", "Deny"], var.genai_storage_account_definition.network_rules.default_action)
+    error_message = "The network_rules.default_action must be one of: 'Allow', 'Deny'."
+  }
+  validation {
+    condition     = var.genai_storage_account_definition.network_rules == null ? true : length(setsubtract(var.genai_storage_account_definition.network_rules.bypass, ["Logging", "Metrics", "AzureServices", "None"])) == 0
+    error_message = "Each network_rules.bypass entry must be one of: 'Logging', 'Metrics', 'AzureServices', 'None'."
+  }
 }

--- a/variables.knowledge_sources.tf
+++ b/variables.knowledge_sources.tf
@@ -17,6 +17,7 @@ variable "ks_ai_search_definition" {
     })), {})
     sku                           = optional(string, "standard")
     local_authentication_enabled  = optional(bool, true)
+    allowed_ips                   = optional(list(string), null)
     network_rule_bypass_option    = optional(string, "None")
     partition_count               = optional(number, 1)
     public_network_access_enabled = optional(bool, false)
@@ -55,6 +56,7 @@ Configuration object for the Azure AI Search service to be created as part of th
   - `marketplace_partner_resource_id` - (Optional) Resource ID of the marketplace partner resource.
 - `sku` - (Optional) The SKU of the AI Search service. Default is "standard".
 - `local_authentication_enabled` - (Optional) Whether local authentication is enabled. Default is true.
+- `allowed_ips` - (Optional) List of IP addresses or CIDR blocks allowed to reach the AI Search service. Default is null (no IP allowlist). Only takes effect when `public_network_access_enabled` is true.
 - `network_rule_bypass_option` - (Optional) Whether trusted Azure services can access a network restricted AI Search service. Possible values are "None" and "AzureServices". Default is "None".
 - `partition_count` - (Optional) The number of partitions for the search service. Default is 1.
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.


### PR DESCRIPTION
## Summary

Closes #143.

Network ACLs and IP allowlists could not be expressed through module inputs, so consumers had to apply `azapi_update_resource` patches out of band after `apply`. That made runs non-idempotent and pushed a security control outside the module's contract. This makes them first-class inputs.

## What changed

**GenAI services and knowledge sources**

| Definition | New inputs |
| --- | --- |
| `genai_storage_account_definition` | `network_rules` |
| `genai_cosmosdb_definition` | `ip_range_filter`, `network_acl_bypass_for_azure_services`, `network_acl_bypass_resource_ids`, `virtual_network_rules` |
| `ks_ai_search_definition` | `allowed_ips` |
| `genai_container_registry_definition` | `network_rule_set`, `network_rule_bypass_option` |
| `genai_app_configuration_definition` | `public_network_access_enabled` |

`genai_key_vault_definition` already had `network_acls`; it is unchanged and was used as the reference shape for the others.

The Cosmos DB firewall was previously hardcoded in `main.genai_services.tf`. It is now driven by `ip_range_filter`, whose default is the same Azure portal and global datacenter source IP list that was inlined before.

Azure App Configuration exposes no IP-based network ACLs at the ARM level, so only `public_network_access_enabled` is surfaced. That is called out explicitly in the variable description so consumers do not go looking for an allowlist that cannot exist.

**AI Foundry**

| Definition | New inputs |
| --- | --- |
| `ai_foundry` | `network_acls`, `public_network_access_enabled` |
| `ai_search_definition` | `network_rule_set`, `public_network_access_enabled` |
| `cosmosdb_definition` | `ip_range_filter`, `network_acl_bypass_for_azure_services`, `network_acl_bypass_resource_ids`, `virtual_network_rules` |
| `key_vault_definition` | `network_acls`, `public_network_access_enabled` |
| `storage_account_definition` | `network_rules`, `public_network_access_enabled` |

The BYOR passthroughs required Azure/terraform-azurerm-avm-ptn-aiml-ai-foundry#139, so the pattern module pin moves from `0.11.2` to `0.11.3`.

## Backward compatibility

Every new input defaults to the value that was previously hardcoded or inherited from the upstream module default, so existing configurations should plan unchanged. Two defaults are deliberate and load bearing:

- **`genai_storage_account_definition.network_rules` defaults to `{}`, not `null`.** `avm-res-storage-storageaccount` treats `null` as "remove all network rules". Defaulting to `null` would have silently opened every existing storage account, so `{}` is used to reproduce the module's implicit deny-by-default.
- **`genai_cosmosdb_definition.network_acl_bypass_for_azure_services` defaults to `true`** to match the previously hardcoded value. The upstream module default is `false`.

Validation blocks were added for the enum-valued fields (`default_action`, `bypass`, `network_rule_bypass_option`), following the existing `ks_ai_search_definition.network_rule_bypass_option` convention.

## Testing

- `terraform fmt -recursive -check` — clean
- `terraform validate` at the root — passes
- `terraform validate` in `examples/default` — passes, with `avm-ptn-aiml-ai-foundry` resolving to `0.11.3`
- `tflint 0.55.1` on the root scope and `examples/default` — zero findings
- `Invoke-AvmDocs` and `Invoke-AvmFormat` — run clean, `README.md` regenerated

`examples/default` now sets `network_rules` on the storage account and `allowed_ips` on AI Search so the new plumbing is exercised end to end. The other three examples are intentionally left on defaults as a regression guard.

Not run locally: the E2E suite, and `Invoke-AvmLint`, which fails in my environment on an unrelated Windows `MAX_PATH` error while staging `examples/default-byo-vnet` (a scope this PR does not touch). Both should be covered by CI here.

## Note for reviewers

The automated triage comment on #143 stated that these inputs needed to be added to the upstream AVM resource modules first. That turned out to be inaccurate for most of them: `avm-res-storage-storageaccount`, `avm-res-documentdb-databaseaccount`, `avm-res-search-searchservice` and `avm-res-containerregistry-registry` all already supported the relevant inputs at the versions pinned here, so those are pure passthroughs. Only the AI Foundry BYOR sub-resources genuinely required an upstream change, which is what #139 delivered.
