### PR TITLE
feat: add Data and AI services contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,46 @@ provider "azurerm" {
 
 These settings are used across the examples to help deployments succeed in policy-restricted environments.
 
+## Data and AI services proposal
+
+This branch contains a human-reviewable, additive proposal for the authorized Data & AI Services parity handoff. It does not claim parity and must not be treated as deployment, release, or publication approval.
+
+### Provenance
+
+- Source implementation: [`Azure/bicep-ptn-aiml-landing-zone@66a0d76f034b8c1003fd63bcdcf58e3255f3d030`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/tree/66a0d76f034b8c1003fd63bcdcf58e3255f3d030).
+- Source contracts: `parity/handoffs/data-and-ai-services/data-and-ai-services-baseline.json` and `parity/inventory.json` at the same commit.
+- Terraform baseline: v0.5.1 commit `abe337894f93de3ddda525ea44898b33e1484070`.
+- Authorization: [Azure/bicep-ptn-aiml-landing-zone#147 comment 5375280499](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499).
+- Expected release impact if accepted: pre-1.0 minor version (for example, `0.6.0`); this proposal does not perform a release.
+
+The baseline Terraform files for these capability groups are unchanged between v0.5.1 and the upstream main used for this proposal.
+
+### Additive service contract
+
+- Standalone GenAI Cosmos DB now composes a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes.
+- Standalone GenAI Storage now composes a private `documents` blob container. Its existing defaults remain GRS replication with shared access keys enabled.
+- Foundry BYOR Storage remains distinct: ZRS replication with shared access keys disabled by default.
+- Application Insights can be created or referenced by resource ID. Existing-component reuse requires an explicitly reused Log Analytics workspace unless `allow_mixed_workspaces` records an intentional exception.
+- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, a private endpoint using `privatelink.cognitiveservices.azure.com`, and deployment-principal `Cognitive Services Contributor` plus `Cognitive Services User` roles.
+- Root outputs contain only non-secret IDs, names, endpoints, regions, managed identity principal IDs, and data-container names. Connection strings, instrumentation keys, and access keys are never exposed.
+
+### Scenario status
+
+| Scenario | Data services | Observability | Search, Bing, Speech |
+| --- | --- | --- | --- |
+| `standalone-network-isolated` | Implemented statically through existing private endpoint, DNS, and peering ordering. | Partial: Log Analytics and Application Insights create/reuse are implemented; AMPLS remains deferred. | Search/Bing are preserved and opt-in Speech uses the existing Cognitive Services private DNS zone and private endpoint subnet. |
+| `standalone-standard` | Blocked by the root module's mandatory VNet/private-endpoint architecture. | Blocked by the same architecture. | Blocked by the same architecture. |
+| `hub-spoke` | Excluded by the authorized handoff. | Excluded by the authorized handoff. | Excluded by the authorized handoff. |
+
+### Exact deferrals and dependencies
+
+- AMPLS, its `azuremonitor` private endpoint, scoped-resource links, and the Azure Monitor/OMS/ODS/Automation private DNS zone set are deferred as one coherent networking change. Application Insights keeps internet ingestion/query enabled by default until that dependency is implemented.
+- Secure runtime propagation of an existing Application Insights connection string is deferred. The module intentionally accepts and outputs only the component resource ID.
+- Cosmos DB SQL data-plane role assignments are deferred pending an AzAPI/AVM implementation decision; ARM role assignments are not a substitute.
+- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Speech executor roles are safe because Speech is a new opt-in resource.
+- Bing-to-Foundry connection wiring remains dependent on the separately scoped Foundry connection capability groups.
+- Approved Azure deployment evidence, DNS resolution, endpoint reachability, RBAC behavior, and isolation comparison remain required before any parity claim.
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 
@@ -45,7 +85,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
@@ -74,10 +114,12 @@ The following resources are used by this module:
 - [random_integer.zone_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [terraform_data.observability_contract](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) (resource)
 - [time_sleep.apim_ready](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [time_sleep.wait_for_kv_rbac](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
+- [azapi_resource.existing_application_insights](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [azurerm_virtual_network.ai_lz_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
@@ -1305,6 +1347,84 @@ object({
 
 Default: `null`
 
+### <a name="input_app_insights_definition"></a> [app\_insights\_definition](#input\_app\_insights\_definition)
+
+Description: Configuration for a workspace-based Application Insights component or an existing component.
+
+- `deploy` - (Optional) Deploy a new component when `resource_id` is not supplied. Default is false to preserve existing Terraform deployments.
+- `resource_id` - (Optional) Resource ID of an existing Application Insights component. The ID is passed through and no connection string is read or output.
+- `name` - (Optional) Component name.
+- `application_type` - (Optional) Application type. Default is "web".
+- `daily_data_cap_in_gb` - (Optional) Daily data cap. Default is 100.
+- `disable_ip_masking` - (Optional) Disable IP masking. Default is false.
+- `internet_ingestion_enabled` - (Optional) Allow internet ingestion. Default is true while AMPLS composition remains deferred.
+- `internet_query_enabled` - (Optional) Allow internet query. Default is true while AMPLS composition remains deferred.
+- `local_authentication_disabled` - (Optional) Disable local authentication. Default is true.
+- `retention_in_days` - (Optional) Retention period. Default is 90.
+- `allow_mixed_workspaces` - (Optional) Allow reuse of Application Insights without an explicitly reused Log Analytics workspace. Default is false.
+- `enable_diagnostic_settings` - (Optional) Enable component diagnostic settings. Default is false.
+- `diagnostic_settings` - (Optional) Component diagnostic settings.
+- `role_assignments` - (Optional) Component-scoped role assignments.
+- `tags` - (Optional) Component tags.
+
+Type:
+
+```hcl
+object({
+    deploy                        = optional(bool, false)
+    resource_id                   = optional(string)
+    name                          = optional(string)
+    application_type              = optional(string, "web")
+    daily_data_cap_in_gb          = optional(number, 100)
+    disable_ip_masking            = optional(bool, false)
+    internet_ingestion_enabled    = optional(bool, true)
+    internet_query_enabled        = optional(bool, true)
+    local_authentication_disabled = optional(bool, true)
+    retention_in_days             = optional(number, 90)
+    allow_mixed_workspaces        = optional(bool, false)
+    enable_diagnostic_settings    = optional(bool, false)
+    diagnostic_settings = optional(map(object({
+      name = optional(string, null)
+      logs = optional(set(object({
+        category       = optional(string, null)
+        category_group = optional(string, null)
+        enabled        = optional(bool, true)
+        retention_policy = optional(object({
+          days    = optional(number, 0)
+          enabled = optional(bool, false)
+        }), {})
+      })), [])
+      metrics = optional(set(object({
+        category = optional(string, null)
+        enabled  = optional(bool, true)
+        retention_policy = optional(object({
+          days    = optional(number, 0)
+          enabled = optional(bool, false)
+        }), {})
+      })), [])
+      log_analytics_destination_type           = optional(string, "Dedicated")
+      workspace_resource_id                    = optional(string, null)
+      storage_account_resource_id              = optional(string, null)
+      event_hub_authorization_rule_resource_id = optional(string, null)
+      event_hub_name                           = optional(string, null)
+      marketplace_partner_resource_id          = optional(string, null)
+    })), {})
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    tags = optional(map(string))
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_bastion_definition"></a> [bastion\_definition](#input\_bastion\_definition)
 
 Description: Configuration object for the Azure Bastion service to be deployed.
@@ -1776,6 +1896,21 @@ Description: Configuration object for the Azure Cosmos DB account to be created 
   - `allowed_origins` - Set of allowed origins.
   - `exposed_headers` - Set of exposed headers.
   - `max_age_in_seconds` - (Optional) Maximum age in seconds for CORS.
+- `sql_databases` - (Optional) SQL databases and containers to create. The default creates the `cosmosdb` database and the `conversations` container with partition key `/principal_id`, infinite TTL, and the source landing zone's composite indexes.
+  - `name` - Database name.
+  - `throughput` - (Optional) Manual database throughput.
+  - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
+  - `containers` - (Optional) SQL containers keyed by an arbitrary map key.
+    - `name` - Container name.
+    - `partition_key_paths` - Partition key paths.
+    - `partition_key_version` - (Optional) Partition key version. Default is 2.
+    - `throughput` - (Optional) Manual container throughput.
+    - `default_ttl` - (Optional) Default time to live. The parity default is -1.
+    - `analytical_storage_ttl` - (Optional) Analytical-store time to live.
+    - `unique_keys` - (Optional) Unique key paths.
+    - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
+    - `conflict_resolution_policy` - (Optional) Conflict-resolution mode and path or procedure.
+    - `indexing_policy` - (Optional) Indexing mode, included/excluded paths, composite indexes, and spatial indexes.
 - `tags` - (Optional) Map of tags to assign to the Cosmos DB account.
 
 Type:
@@ -1836,6 +1971,97 @@ object({
       exposed_headers    = set(string)
       max_age_in_seconds = optional(number, null)
     }), null)
+    sql_databases = optional(map(object({
+      name       = string
+      throughput = optional(number, null)
+      autoscale_settings = optional(object({
+        max_throughput = number
+      }), null)
+      containers = optional(map(object({
+        name                   = string
+        partition_key_paths    = list(string)
+        partition_key_version  = optional(number, 2)
+        throughput             = optional(number, null)
+        default_ttl            = optional(number, null)
+        analytical_storage_ttl = optional(number, null)
+        unique_keys = optional(list(object({
+          paths = set(string)
+        })), [])
+        autoscale_settings = optional(object({
+          max_throughput = number
+        }), null)
+        conflict_resolution_policy = optional(object({
+          mode                          = string
+          conflict_resolution_path      = optional(string, null)
+          conflict_resolution_procedure = optional(string, null)
+        }), null)
+        indexing_policy = optional(object({
+          indexing_mode = string
+          included_paths = optional(set(object({
+            path = string
+          })), [])
+          excluded_paths = optional(set(object({
+            path = string
+          })), [])
+          composite_indexes = optional(set(object({
+            indexes = set(object({
+              path  = string
+              order = string
+            }))
+          })), [])
+          spatial_indexes = optional(set(object({
+            path = string
+          })), [])
+        }), null)
+      })), {})
+      })), {
+      application = {
+        name = "cosmosdb"
+        containers = {
+          conversations = {
+            name                = "conversations"
+            partition_key_paths = ["/principal_id"]
+            default_ttl         = -1
+            indexing_policy = {
+              indexing_mode = "consistent"
+              included_paths = [{
+                path = "/*"
+              }]
+              composite_indexes = [
+                {
+                  indexes = [
+                    {
+                      path  = "/isDeleted"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/_ts"
+                      order = "Descending"
+                    }
+                  ]
+                },
+                {
+                  indexes = [
+                    {
+                      path  = "/isDeleted"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/name"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/_ts"
+                      order = "Descending"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
     tags = optional(map(string))
   })
 ```
@@ -1948,6 +2174,17 @@ Description: Configuration object for the Azure Storage Account to be created fo
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
+- `containers` - (Optional) Blob containers to create. The default creates a private `documents` container.
+  - `name` - Container name.
+  - `public_access` - (Optional) Public access level. Default is "None".
+  - `metadata` - (Optional) Container metadata.
+  - `default_encryption_scope` - (Optional) Default encryption scope.
+  - `deny_encryption_scope_override` - (Optional) Whether clients may override the encryption scope.
+  - `enable_nfs_v3_all_squash` - (Optional) Whether NFSv3 all squash is enabled.
+  - `enable_nfs_v3_root_squash` - (Optional) Whether NFSv3 root squash is enabled.
+  - `immutable_storage_with_versioning` - (Optional) Immutable storage configuration.
+  - `role_assignments` - (Optional) Container-scoped role assignments.
+  - `timeouts` - (Optional) Container operation timeouts.
 - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `role_definition_id_or_name` - The role definition ID or name to assign.
   - `principal_id` - The principal ID to assign the role to.
@@ -1995,10 +2232,40 @@ object({
       delegated_managed_identity_resource_id = optional(string, null)
       principal_type                         = optional(string, null)
     })), {})
+    containers = optional(map(object({
+      name                           = string
+      public_access                  = optional(string, "None")
+      metadata                       = optional(map(string))
+      default_encryption_scope       = optional(string)
+      deny_encryption_scope_override = optional(bool)
+      enable_nfs_v3_all_squash       = optional(bool)
+      enable_nfs_v3_root_squash      = optional(bool)
+      immutable_storage_with_versioning = optional(object({
+        enabled = bool
+      }))
+      role_assignments = optional(map(object({
+        role_definition_id_or_name             = string
+        principal_id                           = string
+        principal_type                         = optional(string, null)
+        description                            = optional(string, null)
+        skip_service_principal_aad_check       = optional(bool, false)
+        condition                              = optional(string, null)
+        condition_version                      = optional(string, null)
+        delegated_managed_identity_resource_id = optional(string, null)
+      })), {})
+      timeouts = optional(object({
+        create = optional(string)
+        delete = optional(string)
+        read   = optional(string)
+        update = optional(string)
+      }))
+      })), {
+      documents = {
+        name          = "documents"
+        public_access = "None"
+      }
+    })
     tags = optional(map(string))
-
-    #TODO:
-    # Implement subservice passthrough here
   })
 ```
 
@@ -2125,6 +2392,62 @@ object({
     name   = optional(string)
     sku    = optional(string, "G1")
     tags   = optional(map(string))
+  })
+```
+
+Default: `{}`
+
+### <a name="input_ks_speech_service_definition"></a> [ks\_speech\_service\_definition](#input\_ks\_speech\_service\_definition)
+
+Description: Configuration for an optional Azure AI Speech account.
+
+- `deploy` - (Optional) Deploy Speech. Default is false.
+- `name` - (Optional) Account and custom subdomain name.
+- `location` - (Optional) Azure region. Defaults to the landing-zone region.
+- `sku` - (Optional) Speech SKU. The network-isolated configuration requires "S0", which is the default.
+- `public_network_access_enabled` - (Optional) Enable public network access. Default is false.
+- `local_authentication_enabled` - (Optional) Enable key-based local authentication. Default is false.
+- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is true.
+- `enable_diagnostic_settings` - (Optional) Enable automatic diagnostics to the effective Log Analytics workspace. Default is true.
+- `diagnostic_settings` - (Optional) Explicit diagnostic settings, which take precedence over the automatic setting.
+- `role_assignments` - (Optional) Additional account-scoped role assignments for workload identities.
+- `tags` - (Optional) Account tags.
+
+Type:
+
+```hcl
+object({
+    deploy                           = optional(bool, false)
+    name                             = optional(string)
+    location                         = optional(string)
+    sku                              = optional(string, "S0")
+    public_network_access_enabled    = optional(bool, false)
+    local_authentication_enabled     = optional(bool, false)
+    assign_deployment_principal_rbac = optional(bool, true)
+    enable_diagnostic_settings       = optional(bool, true)
+    diagnostic_settings = optional(map(object({
+      name                                     = optional(string, null)
+      log_categories                           = optional(set(string), [])
+      log_groups                               = optional(set(string), ["allLogs"])
+      metric_categories                        = optional(set(string), ["AllMetrics"])
+      log_analytics_destination_type           = optional(string, "Dedicated")
+      workspace_resource_id                    = optional(string, null)
+      storage_account_resource_id              = optional(string, null)
+      event_hub_authorization_rule_resource_id = optional(string, null)
+      event_hub_name                           = optional(string, null)
+      marketplace_partner_resource_id          = optional(string, null)
+    })), {})
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    tags = optional(map(string))
   })
 ```
 
@@ -2385,6 +2708,18 @@ The following outputs are exported:
 
 Description: Details of the deployed APIM instance.
 
+### <a name="output_application_insights_name"></a> [application\_insights\_name](#output\_application\_insights\_name)
+
+Description: The name of the created Application Insights component, or null when an existing component is reused.
+
+### <a name="output_application_insights_resource_id"></a> [application\_insights\_resource\_id](#output\_application\_insights\_resource\_id)
+
+Description: The resource ID of the created or reused Application Insights component. No connection string or instrumentation key is exposed.
+
+### <a name="output_data_ai_services"></a> [data\_ai\_services](#output\_data\_ai\_services)
+
+Description: Non-secret resource and runtime-discovery values for the Data & AI services parity contract.
+
 ### <a name="output_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#output\_log\_analytics\_workspace\_id)
 
 Description: The ID of the Log Analytics Workspace used for monitoring.
@@ -2434,6 +2769,12 @@ Version: 0.2.0
 Source: Azure/avm-res-network-applicationgateway/azurerm
 
 Version: 0.4.2
+
+### <a name="module_application_insights"></a> [application\_insights](#module\_application\_insights)
+
+Source: Azure/avm-res-insights-component/azurerm
+
+Version: 0.4.0
 
 ### <a name="module_avm_res_keyvault_vault"></a> [avm\_res\_keyvault\_vault](#module\_avm\_res\_keyvault\_vault)
 
@@ -2560,6 +2901,12 @@ Version: 0.4.2
 Source: Azure/avm-res-search-searchservice/azurerm
 
 Version: 0.2.0
+
+### <a name="module_speech_service"></a> [speech\_service](#module\_speech\_service)
+
+Source: Azure/avm-res-cognitiveservices-account/azurerm
+
+Version: 0.11.1
 
 ### <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account)
 

--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ Description: Configuration for a workspace-based Application Insights component 
 - `retention_in_days` - (Optional) Retention period. Default is 90.
 - `allow_mixed_workspaces` - (Optional) Allow reuse of Application Insights without an explicitly reused Log Analytics workspace. Default is false.
 - `enable_diagnostic_settings` - (Optional) Enable component diagnostic settings. Default is false.
-- `diagnostic_settings` - (Optional) Component diagnostic settings.
+- `diagnostic_settings` - (Optional) Component diagnostic settings. When diagnostics are enabled and this map is empty, the automatic setting collects the `allLogs` category group and `AllMetrics`. Supplied settings are preserved without adding categories.
 - `role_assignments` - (Optional) Component-scoped role assignments.
 - `tags` - (Optional) Component tags.
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The baseline Terraform files for these capability groups are unchanged between v
 
 ### Additive service contract
 
-- Standalone GenAI Cosmos DB now composes a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes.
-- Standalone GenAI Storage now composes a private `documents` blob container. Its existing defaults remain GRS replication with shared access keys enabled.
+- Standalone GenAI Cosmos DB can explicitly compose a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes. `sql_databases` defaults to empty.
+- Standalone GenAI Storage can explicitly compose a private `documents` blob container. `containers` defaults to empty; the account's existing defaults remain GRS replication with shared access keys enabled.
 - Foundry BYOR Storage remains distinct: ZRS replication with shared access keys disabled by default.
 - Application Insights can be created or referenced by resource ID. Existing-component reuse requires an explicitly reused Log Analytics workspace unless `allow_mixed_workspaces` records an intentional exception.
-- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, a private endpoint using `privatelink.cognitiveservices.azure.com`, and deployment-principal `Cognitive Services Contributor` plus `Cognitive Services User` roles.
+- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, and a private endpoint using `privatelink.cognitiveservices.azure.com`. Deployment-principal RBAC is separately opt-in and defaults to disabled.
 - Root outputs contain only non-secret IDs, names, endpoints, regions, managed identity principal IDs, and data-container names. Connection strings, instrumentation keys, and access keys are never exposed.
 
 ### Scenario status
@@ -74,9 +74,17 @@ The baseline Terraform files for these capability groups are unchanged between v
 - AMPLS, its `azuremonitor` private endpoint, scoped-resource links, and the Azure Monitor/OMS/ODS/Automation private DNS zone set are deferred as one coherent networking change. Application Insights keeps internet ingestion/query enabled by default until that dependency is implemented.
 - Secure runtime propagation of an existing Application Insights connection string is deferred. The module intentionally accepts and outputs only the component resource ID.
 - Cosmos DB SQL data-plane role assignments are deferred pending an AzAPI/AVM implementation decision; ARM role assignments are not a substitute.
-- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Speech executor roles are safe because Speech is a new opt-in resource.
+- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Creating the Speech account, managed identity, private endpoint, and diagnostics requires control-plane deployment permission but does not require persistent Cognitive Services data-plane roles. Set `assign_deployment_principal_rbac = true` only when that principal must perform post-deployment Cognitive Services operations; this grants exactly Cognitive Services Contributor and Cognitive Services User at the Speech account scope.
 - Bing-to-Foundry connection wiring remains dependent on the separately scoped Foundry connection capability groups.
 - Approved Azure deployment evidence, DNS resolution, endpoint reachability, RBAC behavior, and isolation comparison remain required before any parity claim.
+
+### Upgrade and release guidance
+
+- The proposed Data & AI capability set is additive and is expected to ship in a pre-1.0 minor release (for example, `0.6.0`), not a patch release.
+- `genai_cosmosdb_definition.sql_databases` and `genai_storage_account_definition.containers` deliberately default to `{}`. Existing consumers can upgrade without Terraform silently creating or colliding with databases, Cosmos containers, or blob containers.
+- Consumers that want the Bicep parity preset must copy the explicit `cosmosdb`/`conversations` and `documents` definitions from [`examples/standalone-byo-vnet`](./examples/standalone-byo-vnet). If equivalent child resources already exist, import them into the child-module addresses before enabling the preset.
+- `ks_speech_service_definition.assign_deployment_principal_rbac` defaults to `false`. Consumers that intentionally depended on the earlier proposal default must opt in explicitly and review the two persistent account-scoped assignments.
+- Non-empty `ignore_body_changes` values use the AzAPI write-only lifecycle interface and therefore require Terraform 1.11 or later; the default empty value remains compatible with the module's Terraform 1.9 minimum.
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements
@@ -104,7 +112,16 @@ The following resources are used by this module:
 - [azapi_resource.apim_api_operation_list_models](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.apim_api_policy_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.apim_backend_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.application_insights](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.application_insights_diagnostic_setting](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.application_insights_role_assignment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.bing_grounding](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.speech_diagnostic_setting](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.speech_private_dns_zone_group](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.speech_private_endpoint](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.speech_role_assignment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.speech_service](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource_action.application_insights_daily_cap](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_network_security_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
@@ -120,6 +137,8 @@ The following resources are used by this module:
 - [time_sleep.wait_for_kv_rbac](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azapi_resource.existing_application_insights](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
+- [azapi_resource_list.app_insights_role_definition](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_list) (data source)
+- [azapi_resource_list.ks_speech_role_definition](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_list) (data source)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [azurerm_virtual_network.ai_lz_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
@@ -1896,7 +1915,7 @@ Description: Configuration object for the Azure Cosmos DB account to be created 
   - `allowed_origins` - Set of allowed origins.
   - `exposed_headers` - Set of exposed headers.
   - `max_age_in_seconds` - (Optional) Maximum age in seconds for CORS.
-- `sql_databases` - (Optional) SQL databases and containers to create. The default creates the `cosmosdb` database and the `conversations` container with partition key `/principal_id`, infinite TTL, and the source landing zone's composite indexes.
+- `sql_databases` - (Optional) SQL databases and containers to create. Default is empty so an upgrade never creates or collides with child resources implicitly.
   - `name` - Database name.
   - `throughput` - (Optional) Manual database throughput.
   - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
@@ -2014,54 +2033,7 @@ object({
           })), [])
         }), null)
       })), {})
-      })), {
-      application = {
-        name = "cosmosdb"
-        containers = {
-          conversations = {
-            name                = "conversations"
-            partition_key_paths = ["/principal_id"]
-            default_ttl         = -1
-            indexing_policy = {
-              indexing_mode = "consistent"
-              included_paths = [{
-                path = "/*"
-              }]
-              composite_indexes = [
-                {
-                  indexes = [
-                    {
-                      path  = "/isDeleted"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/_ts"
-                      order = "Descending"
-                    }
-                  ]
-                },
-                {
-                  indexes = [
-                    {
-                      path  = "/isDeleted"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/name"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/_ts"
-                      order = "Descending"
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      }
-    })
+    })), {})
     tags = optional(map(string))
   })
 ```
@@ -2174,7 +2146,7 @@ Description: Configuration object for the Azure Storage Account to be created fo
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
-- `containers` - (Optional) Blob containers to create. The default creates a private `documents` container.
+- `containers` - (Optional) Blob containers to create. Default is empty so an upgrade never creates or collides with child resources implicitly.
   - `name` - Container name.
   - `public_access` - (Optional) Public access level. Default is "None".
   - `metadata` - (Optional) Container metadata.
@@ -2259,13 +2231,44 @@ object({
         read   = optional(string)
         update = optional(string)
       }))
-      })), {
-      documents = {
-        name          = "documents"
-        public_access = "None"
-      }
-    })
+    })), {})
     tags = optional(map(string))
+  })
+```
+
+Default: `{}`
+
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body paths whose changes AzAPI should ignore, keyed by Azure resource type. Paths use dot notation and changes take effect only after apply. Non-empty values require Terraform 1.11 or later.
+
+- `apimanagement_service_apis` - API Management API body paths.
+- `apimanagement_service_apis_operations` - API Management API-operation body paths.
+- `apimanagement_service_apis_policies` - API Management API-policy body paths.
+- `apimanagement_service_backends` - API Management backend body paths.
+- `authorization_role_assignments` - Role-assignment body paths.
+- `bing_accounts` - Grounding with Bing account body paths.
+- `cognitiveservices_accounts` - Cognitive Services account body paths.
+- `insights_components` - Application Insights component body paths.
+- `insights_diagnostic_settings` - Diagnostic-setting body paths.
+- `network_private_endpoints` - Private endpoint body paths.
+- `network_private_endpoints_private_dns_zone_groups` - Private endpoint DNS-zone-group body paths.
+
+Type:
+
+```hcl
+object({
+    apimanagement_service_apis                        = optional(list(string), [])
+    apimanagement_service_apis_operations             = optional(list(string), [])
+    apimanagement_service_apis_policies               = optional(list(string), [])
+    apimanagement_service_backends                    = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    bing_accounts                                     = optional(list(string), [])
+    cognitiveservices_accounts                        = optional(list(string), [])
+    insights_components                               = optional(list(string), [])
+    insights_diagnostic_settings                      = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
   })
 ```
 
@@ -2407,7 +2410,7 @@ Description: Configuration for an optional Azure AI Speech account.
 - `sku` - (Optional) Speech SKU. The network-isolated configuration requires "S0", which is the default.
 - `public_network_access_enabled` - (Optional) Enable public network access. Default is false.
 - `local_authentication_enabled` - (Optional) Enable key-based local authentication. Default is false.
-- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is true.
+- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is false. Account creation and managed-identity authentication do not require these persistent data-plane roles; enable only when the deployment principal must perform post-deployment Cognitive Services operations.
 - `enable_diagnostic_settings` - (Optional) Enable automatic diagnostics to the effective Log Analytics workspace. Default is true.
 - `diagnostic_settings` - (Optional) Explicit diagnostic settings, which take precedence over the automatic setting.
 - `role_assignments` - (Optional) Additional account-scoped role assignments for workload identities.
@@ -2423,7 +2426,7 @@ object({
     sku                              = optional(string, "S0")
     public_network_access_enabled    = optional(bool, false)
     local_authentication_enabled     = optional(bool, false)
-    assign_deployment_principal_rbac = optional(bool, true)
+    assign_deployment_principal_rbac = optional(bool, false)
     enable_diagnostic_settings       = optional(bool, true)
     diagnostic_settings = optional(map(object({
       name                                     = optional(string, null)
@@ -2581,6 +2584,66 @@ object({
 
 Default: `{}`
 
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: Azure resource type and API-version overrides for resources managed directly with AzAPI.
+
+- `apimanagement_service_apis` - API Management APIs.
+- `apimanagement_service_apis_operations` - API Management API operations.
+- `apimanagement_service_apis_policies` - API Management API policies.
+- `apimanagement_service_backends` - API Management backends.
+- `authorization_role_assignments` - Azure role assignments.
+- `bing_accounts` - Grounding with Bing accounts.
+- `cognitiveservices_accounts` - Cognitive Services accounts, including Speech.
+- `cognitiveservices_locations_resource_groups_deleted_accounts` - Cognitive Services deleted-account purge endpoint.
+- `insights_components` - Application Insights components.
+- `insights_components_currentbillingfeatures` - Application Insights current billing features singleton.
+- `insights_diagnostic_settings` - Azure Monitor diagnostic settings.
+- `network_private_endpoints` - Private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Private endpoint DNS zone groups.
+
+Type:
+
+```hcl
+object({
+    apimanagement_service_apis                                   = optional(string, "Microsoft.ApiManagement/service/apis@2024-05-01")
+    apimanagement_service_apis_operations                        = optional(string, "Microsoft.ApiManagement/service/apis/operations@2024-05-01")
+    apimanagement_service_apis_policies                          = optional(string, "Microsoft.ApiManagement/service/apis/policies@2024-05-01")
+    apimanagement_service_backends                               = optional(string, "Microsoft.ApiManagement/service/backends@2024-05-01")
+    authorization_role_assignments                               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    bing_accounts                                                = optional(string, "Microsoft.Bing/accounts@2025-05-01-preview")
+    cognitiveservices_accounts                                   = optional(string, "Microsoft.CognitiveServices/accounts@2025-06-01")
+    cognitiveservices_locations_resource_groups_deleted_accounts = optional(string, "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30")
+    insights_components                                          = optional(string, "Microsoft.Insights/components@2020-02-02")
+    insights_components_currentbillingfeatures                   = optional(string, "Microsoft.Insights/components@2015-05-01")
+    insights_diagnostic_settings                                 = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_private_endpoints                                    = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups            = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+  })
+```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration applied to every AzAPI resource declared directly by this module.
+
+- `error_message_regex` - (Optional) Error-message patterns that trigger retry.
+- `interval_seconds` - (Optional) Initial retry interval in seconds.
+- `max_interval_seconds` - (Optional) Maximum retry interval in seconds.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["ScopeLocked", "Account.*state Accepted"])
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: Map of tags to be assigned to all resources created by this module.
@@ -2588,6 +2651,28 @@ Description: Map of tags to be assigned to all resources created by this module.
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Default operation timeouts applied to every AzAPI resource declared directly by this module.
+
+- `create` - (Optional) Create timeout as a Go duration string.
+- `delete` - (Optional) Delete timeout as a Go duration string.
+- `read` - (Optional) Read timeout as a Go duration string.
+- `update` - (Optional) Update timeout as a Go duration string.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 
@@ -2770,12 +2855,6 @@ Source: Azure/avm-res-network-applicationgateway/azurerm
 
 Version: 0.4.2
 
-### <a name="module_application_insights"></a> [application\_insights](#module\_application\_insights)
-
-Source: Azure/avm-res-insights-component/azurerm
-
-Version: 0.4.0
-
 ### <a name="module_avm_res_keyvault_vault"></a> [avm\_res\_keyvault\_vault](#module\_avm\_res\_keyvault\_vault)
 
 Source: Azure/avm-res-keyvault-vault/azurerm
@@ -2901,12 +2980,6 @@ Version: 0.4.2
 Source: Azure/avm-res-search-searchservice/azurerm
 
 Version: 0.2.0
-
-### <a name="module_speech_service"></a> [speech\_service](#module\_speech\_service)
-
-Source: Azure/avm-res-cognitiveservices-account/azurerm
-
-Version: 0.11.1
 
 ### <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account)
 

--- a/_header.md
+++ b/_header.md
@@ -35,3 +35,43 @@ provider "azurerm" {
 ```
 
 These settings are used across the examples to help deployments succeed in policy-restricted environments.
+
+## Data and AI services proposal
+
+This branch contains a human-reviewable, additive proposal for the authorized Data & AI Services parity handoff. It does not claim parity and must not be treated as deployment, release, or publication approval.
+
+### Provenance
+
+- Source implementation: [`Azure/bicep-ptn-aiml-landing-zone@66a0d76f034b8c1003fd63bcdcf58e3255f3d030`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/tree/66a0d76f034b8c1003fd63bcdcf58e3255f3d030).
+- Source contracts: `parity/handoffs/data-and-ai-services/data-and-ai-services-baseline.json` and `parity/inventory.json` at the same commit.
+- Terraform baseline: v0.5.1 commit `abe337894f93de3ddda525ea44898b33e1484070`.
+- Authorization: [Azure/bicep-ptn-aiml-landing-zone#147 comment 5375280499](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499).
+- Expected release impact if accepted: pre-1.0 minor version (for example, `0.6.0`); this proposal does not perform a release.
+
+The baseline Terraform files for these capability groups are unchanged between v0.5.1 and the upstream main used for this proposal.
+
+### Additive service contract
+
+- Standalone GenAI Cosmos DB now composes a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes.
+- Standalone GenAI Storage now composes a private `documents` blob container. Its existing defaults remain GRS replication with shared access keys enabled.
+- Foundry BYOR Storage remains distinct: ZRS replication with shared access keys disabled by default.
+- Application Insights can be created or referenced by resource ID. Existing-component reuse requires an explicitly reused Log Analytics workspace unless `allow_mixed_workspaces` records an intentional exception.
+- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, a private endpoint using `privatelink.cognitiveservices.azure.com`, and deployment-principal `Cognitive Services Contributor` plus `Cognitive Services User` roles.
+- Root outputs contain only non-secret IDs, names, endpoints, regions, managed identity principal IDs, and data-container names. Connection strings, instrumentation keys, and access keys are never exposed.
+
+### Scenario status
+
+| Scenario | Data services | Observability | Search, Bing, Speech |
+| --- | --- | --- | --- |
+| `standalone-network-isolated` | Implemented statically through existing private endpoint, DNS, and peering ordering. | Partial: Log Analytics and Application Insights create/reuse are implemented; AMPLS remains deferred. | Search/Bing are preserved and opt-in Speech uses the existing Cognitive Services private DNS zone and private endpoint subnet. |
+| `standalone-standard` | Blocked by the root module's mandatory VNet/private-endpoint architecture. | Blocked by the same architecture. | Blocked by the same architecture. |
+| `hub-spoke` | Excluded by the authorized handoff. | Excluded by the authorized handoff. | Excluded by the authorized handoff. |
+
+### Exact deferrals and dependencies
+
+- AMPLS, its `azuremonitor` private endpoint, scoped-resource links, and the Azure Monitor/OMS/ODS/Automation private DNS zone set are deferred as one coherent networking change. Application Insights keeps internet ingestion/query enabled by default until that dependency is implemented.
+- Secure runtime propagation of an existing Application Insights connection string is deferred. The module intentionally accepts and outputs only the component resource ID.
+- Cosmos DB SQL data-plane role assignments are deferred pending an AzAPI/AVM implementation decision; ARM role assignments are not a substitute.
+- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Speech executor roles are safe because Speech is a new opt-in resource.
+- Bing-to-Foundry connection wiring remains dependent on the separately scoped Foundry connection capability groups.
+- Approved Azure deployment evidence, DNS resolution, endpoint reachability, RBAC behavior, and isolation comparison remain required before any parity claim.

--- a/_header.md
+++ b/_header.md
@@ -52,11 +52,11 @@ The baseline Terraform files for these capability groups are unchanged between v
 
 ### Additive service contract
 
-- Standalone GenAI Cosmos DB now composes a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes.
-- Standalone GenAI Storage now composes a private `documents` blob container. Its existing defaults remain GRS replication with shared access keys enabled.
+- Standalone GenAI Cosmos DB can explicitly compose a `cosmosdb` SQL database with a `conversations` container, `/principal_id` partition key, infinite default TTL, and the two source composite indexes. `sql_databases` defaults to empty.
+- Standalone GenAI Storage can explicitly compose a private `documents` blob container. `containers` defaults to empty; the account's existing defaults remain GRS replication with shared access keys enabled.
 - Foundry BYOR Storage remains distinct: ZRS replication with shared access keys disabled by default.
 - Application Insights can be created or referenced by resource ID. Existing-component reuse requires an explicitly reused Log Analytics workspace unless `allow_mixed_workspaces` records an intentional exception.
-- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, a private endpoint using `privatelink.cognitiveservices.azure.com`, and deployment-principal `Cognitive Services Contributor` plus `Cognitive Services User` roles.
+- Azure AI Speech is opt-in and defaults to `S0`, system-assigned managed identity, disabled local authentication, disabled public network access, and a private endpoint using `privatelink.cognitiveservices.azure.com`. Deployment-principal RBAC is separately opt-in and defaults to disabled.
 - Root outputs contain only non-secret IDs, names, endpoints, regions, managed identity principal IDs, and data-container names. Connection strings, instrumentation keys, and access keys are never exposed.
 
 ### Scenario status
@@ -72,6 +72,14 @@ The baseline Terraform files for these capability groups are unchanged between v
 - AMPLS, its `azuremonitor` private endpoint, scoped-resource links, and the Azure Monitor/OMS/ODS/Automation private DNS zone set are deferred as one coherent networking change. Application Insights keeps internet ingestion/query enabled by default until that dependency is implemented.
 - Secure runtime propagation of an existing Application Insights connection string is deferred. The module intentionally accepts and outputs only the component resource ID.
 - Cosmos DB SQL data-plane role assignments are deferred pending an AzAPI/AVM implementation decision; ARM role assignments are not a substitute.
-- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Speech executor roles are safe because Speech is a new opt-in resource.
+- Default Search, Storage, Key Vault, and workload-identity data-plane role changes are deferred because silently changing existing defaults would violate the migration-free handoff. Creating the Speech account, managed identity, private endpoint, and diagnostics requires control-plane deployment permission but does not require persistent Cognitive Services data-plane roles. Set `assign_deployment_principal_rbac = true` only when that principal must perform post-deployment Cognitive Services operations; this grants exactly Cognitive Services Contributor and Cognitive Services User at the Speech account scope.
 - Bing-to-Foundry connection wiring remains dependent on the separately scoped Foundry connection capability groups.
 - Approved Azure deployment evidence, DNS resolution, endpoint reachability, RBAC behavior, and isolation comparison remain required before any parity claim.
+
+### Upgrade and release guidance
+
+- The proposed Data & AI capability set is additive and is expected to ship in a pre-1.0 minor release (for example, `0.6.0`), not a patch release.
+- `genai_cosmosdb_definition.sql_databases` and `genai_storage_account_definition.containers` deliberately default to `{}`. Existing consumers can upgrade without Terraform silently creating or colliding with databases, Cosmos containers, or blob containers.
+- Consumers that want the Bicep parity preset must copy the explicit `cosmosdb`/`conversations` and `documents` definitions from [`examples/standalone-byo-vnet`](./examples/standalone-byo-vnet). If equivalent child resources already exist, import them into the child-module addresses before enabling the preset.
+- `ks_speech_service_definition.assign_deployment_principal_rbac` defaults to `false`. Consumers that intentionally depended on the earlier proposal default must opt in explicitly and review the two persistent account-scoped assignments.
+- Non-empty `ignore_body_changes` values use the AzAPI write-only lifecycle interface and therefore require Terraform 1.11 or later; the default empty value remains compatible with the module's Terraform 1.9 minimum.

--- a/examples/standalone-byo-vnet/README.md
+++ b/examples/standalone-byo-vnet/README.md
@@ -119,6 +119,9 @@ module "test" {
 
   location            = local.location
   resource_group_name = "ai-lz-rg-standalone-byo-vnet-${substr(module.naming.unique-seed, 0, 5)}"
+  app_insights_definition = {
+    deploy = true
+  }
   #resource_group_name = "ai-lz-rg-default-ivrhi-4"
   vnet_definition = {
     existing_byo_vnet = {
@@ -251,6 +254,37 @@ module "test" {
   }
   genai_cosmosdb_definition = {
     consistency_level = "Session"
+    sql_databases = {
+      application = {
+        name = "cosmosdb"
+        containers = {
+          conversations = {
+            name                = "conversations"
+            partition_key_paths = ["/principal_id"]
+            default_ttl         = -1
+            indexing_policy = {
+              indexing_mode  = "consistent"
+              included_paths = [{ path = "/*" }]
+              composite_indexes = [
+                {
+                  indexes = [
+                    { path = "/isDeleted", order = "Ascending" },
+                    { path = "/_ts", order = "Descending" }
+                  ]
+                },
+                {
+                  indexes = [
+                    { path = "/isDeleted", order = "Ascending" },
+                    { path = "/name", order = "Ascending" },
+                    { path = "/_ts", order = "Descending" }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
   }
   genai_key_vault_definition = {
     #this is for AVM testing purposes only. Doing this as we don't have an easy for the test runner to be privately connected for testing.
@@ -261,12 +295,23 @@ module "test" {
     }
   }
   genai_storage_account_definition = {
+    containers = {
+      documents = {
+        name          = "documents"
+        public_access = "None"
+      }
+    }
   }
   jumpvm_definition = {
     sku = module.vm_sku.sku
   }
   ks_ai_search_definition = {
     enable_diagnostic_settings = false
+  }
+  ks_speech_service_definition = {
+    deploy                     = true
+    enable_diagnostic_settings = false
+    sku                        = "S0"
   }
   tags = {
     SecurityControl = "Ignore"

--- a/examples/standalone-byo-vnet/README.md
+++ b/examples/standalone-byo-vnet/README.md
@@ -309,9 +309,10 @@ module "test" {
     enable_diagnostic_settings = false
   }
   ks_speech_service_definition = {
-    deploy                     = true
-    enable_diagnostic_settings = false
-    sku                        = "S0"
+    deploy                           = true
+    assign_deployment_principal_rbac = false
+    enable_diagnostic_settings       = false
+    sku                              = "S0"
   }
   tags = {
     SecurityControl = "Ignore"

--- a/examples/standalone-byo-vnet/main.tf
+++ b/examples/standalone-byo-vnet/main.tf
@@ -112,6 +112,9 @@ module "test" {
 
   location            = local.location
   resource_group_name = "ai-lz-rg-standalone-byo-vnet-${substr(module.naming.unique-seed, 0, 5)}"
+  app_insights_definition = {
+    deploy = true
+  }
   #resource_group_name = "ai-lz-rg-default-ivrhi-4"
   vnet_definition = {
     existing_byo_vnet = {
@@ -244,6 +247,37 @@ module "test" {
   }
   genai_cosmosdb_definition = {
     consistency_level = "Session"
+    sql_databases = {
+      application = {
+        name = "cosmosdb"
+        containers = {
+          conversations = {
+            name                = "conversations"
+            partition_key_paths = ["/principal_id"]
+            default_ttl         = -1
+            indexing_policy = {
+              indexing_mode  = "consistent"
+              included_paths = [{ path = "/*" }]
+              composite_indexes = [
+                {
+                  indexes = [
+                    { path = "/isDeleted", order = "Ascending" },
+                    { path = "/_ts", order = "Descending" }
+                  ]
+                },
+                {
+                  indexes = [
+                    { path = "/isDeleted", order = "Ascending" },
+                    { path = "/name", order = "Ascending" },
+                    { path = "/_ts", order = "Descending" }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
   }
   genai_key_vault_definition = {
     #this is for AVM testing purposes only. Doing this as we don't have an easy for the test runner to be privately connected for testing.
@@ -254,12 +288,23 @@ module "test" {
     }
   }
   genai_storage_account_definition = {
+    containers = {
+      documents = {
+        name          = "documents"
+        public_access = "None"
+      }
+    }
   }
   jumpvm_definition = {
     sku = module.vm_sku.sku
   }
   ks_ai_search_definition = {
     enable_diagnostic_settings = false
+  }
+  ks_speech_service_definition = {
+    deploy                     = true
+    enable_diagnostic_settings = false
+    sku                        = "S0"
   }
   tags = {
     SecurityControl = "Ignore"

--- a/examples/standalone-byo-vnet/main.tf
+++ b/examples/standalone-byo-vnet/main.tf
@@ -302,9 +302,10 @@ module "test" {
     enable_diagnostic_settings = false
   }
   ks_speech_service_definition = {
-    deploy                     = true
-    enable_diagnostic_settings = false
-    sku                        = "S0"
+    deploy                           = true
+    assign_deployment_principal_rbac = false
+    enable_diagnostic_settings       = false
+    sku                              = "S0"
   }
   tags = {
     SecurityControl = "Ignore"

--- a/locals.knowledge_sources.tf
+++ b/locals.knowledge_sources.tf
@@ -17,4 +17,33 @@ locals {
   ks_ai_search_name             = try(var.ks_ai_search_definition.name, null) != null ? var.ks_ai_search_definition.name : (var.name_prefix != null ? "${var.name_prefix}-ks-ai-search" : "ai-alz-ks-ai-search-${random_string.name_suffix.result}")
   ks_ai_search_role_assignments = try(var.ks_ai_search_definition.role_assignments, {})
   ks_bing_grounding_name        = try(var.ks_bing_grounding_definition.name, null) != null ? var.ks_bing_grounding_definition.name : (var.name_prefix != null ? "${var.name_prefix}-ks-bing-grounding" : "ai-alz-ks-bing-grounding-${random_string.name_suffix.result}")
+  ks_speech_service_name        = try(var.ks_speech_service_definition.name, null) != null ? var.ks_speech_service_definition.name : (var.name_prefix != null ? "${var.name_prefix}-speech" : "ai-alz-speech-${random_string.name_suffix.result}")
+  ks_speech_service_location    = try(var.ks_speech_service_definition.location, null) != null ? var.ks_speech_service_definition.location : var.location
+  ks_speech_diagnostic_settings = var.ks_speech_service_definition.enable_diagnostic_settings ? (length(var.ks_speech_service_definition.diagnostic_settings) > 0 ? var.ks_speech_service_definition.diagnostic_settings : (
+    local.deploy_diagnostics_settings ? {
+      sendToLogAnalytics = {
+        name                                     = "sendToLogAnalytics-ks-speech-${random_string.name_suffix.result}"
+        workspace_resource_id                    = local.log_analytics_workspace_id
+        log_analytics_destination_type           = "Dedicated"
+        log_groups                               = ["allLogs"]
+        metric_categories                        = ["AllMetrics"]
+        log_categories                           = []
+        storage_account_resource_id              = null
+        event_hub_authorization_rule_resource_id = null
+        event_hub_name                           = null
+        marketplace_partner_resource_id          = null
+      }
+    } : {}
+  )) : {}
+  ks_speech_default_role_assignments = var.ks_speech_service_definition.assign_deployment_principal_rbac ? {
+    deployment_principal_contributor = {
+      role_definition_id_or_name = "Cognitive Services Contributor"
+      principal_id               = data.azurerm_client_config.current.object_id
+    }
+    deployment_principal_user = {
+      role_definition_id_or_name = "Cognitive Services User"
+      principal_id               = data.azurerm_client_config.current.object_id
+    }
+  } : {}
+  ks_speech_role_assignments = merge(local.ks_speech_default_role_assignments, var.ks_speech_service_definition.role_assignments)
 }

--- a/locals.knowledge_sources.tf
+++ b/locals.knowledge_sources.tf
@@ -37,13 +37,23 @@ locals {
   )) : {}
   ks_speech_default_role_assignments = var.ks_speech_service_definition.assign_deployment_principal_rbac ? {
     deployment_principal_contributor = {
-      role_definition_id_or_name = "Cognitive Services Contributor"
+      role_definition_id_or_name = "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68"
       principal_id               = data.azurerm_client_config.current.object_id
     }
     deployment_principal_user = {
-      role_definition_id_or_name = "Cognitive Services User"
+      role_definition_id_or_name = "a97b65f3-24c7-4388-baec-2e87135dc908"
       principal_id               = data.azurerm_client_config.current.object_id
     }
   } : {}
-  ks_speech_role_assignments = merge(local.ks_speech_default_role_assignments, var.ks_speech_service_definition.role_assignments)
+  ks_speech_role_assignments       = merge(local.ks_speech_default_role_assignments, var.ks_speech_service_definition.role_assignments)
+  ks_speech_named_role_assignments = { for key, assignment in local.ks_speech_role_assignments : key => assignment if !startswith(assignment.role_definition_id_or_name, "/") && !can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", assignment.role_definition_id_or_name)) }
+  ks_speech_resolved_role_assignments = { for key, assignment in local.ks_speech_role_assignments : key => merge(assignment, {
+    role_definition_id = startswith(assignment.role_definition_id_or_name, "/") ? assignment.role_definition_id_or_name : (
+      can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", assignment.role_definition_id_or_name)) ?
+      "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/${assignment.role_definition_id_or_name}" :
+      data.azapi_resource_list.ks_speech_role_definition[key].output.role_definition_id
+    )
+  }) }
+  ks_speech_private_endpoint_name = "pep-${local.ks_speech_service_name}"
+  ks_speech_private_dns_zone_id   = var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? null : (!var.flag_platform_landing_zone ? module.private_dns_zones.ai_foundry_cognitive_services_zone.resource_id : local.private_dns_zones_existing.ai_foundry_cognitive_services_zone.resource_id)
 }

--- a/locals.monitoring.tf
+++ b/locals.monitoring.tf
@@ -5,4 +5,12 @@ locals {
   deploy_diagnostics_settings  = var.law_definition.resource_id != null || var.law_definition.deploy
   log_analytics_workspace_id   = var.law_definition.resource_id != null ? var.law_definition.resource_id : (length(module.log_analytics_workspace) > 0 ? module.log_analytics_workspace[0].resource_id : null)
   log_analytics_workspace_name = try(var.law_definition.name, null) != null ? var.law_definition.name : (var.name_prefix != null ? "${var.name_prefix}-law" : "ai-alz-law")
+  app_insights_diagnostic_settings = !var.app_insights_definition.enable_diagnostic_settings ? {} : (length(var.app_insights_definition.diagnostic_settings) > 0 ? var.app_insights_definition.diagnostic_settings : {
+    sendToLogAnalytics = {
+      workspace_resource_id = local.log_analytics_workspace_id
+    }
+  })
+  app_insights_location    = lower(var.location) == "westcentralus" ? "eastus" : var.location
+  app_insights_name        = try(var.app_insights_definition.name, null) != null ? var.app_insights_definition.name : (var.name_prefix != null ? "${var.name_prefix}-app-insights" : "ai-alz-app-insights-${random_string.name_suffix.result}")
+  app_insights_resource_id = var.app_insights_definition.resource_id != null ? var.app_insights_definition.resource_id : (length(module.application_insights) > 0 ? module.application_insights[0].resource_id : null)
 }

--- a/locals.monitoring.tf
+++ b/locals.monitoring.tf
@@ -5,11 +5,34 @@ locals {
   deploy_diagnostics_settings  = var.law_definition.resource_id != null || var.law_definition.deploy
   log_analytics_workspace_id   = var.law_definition.resource_id != null ? var.law_definition.resource_id : (length(module.log_analytics_workspace) > 0 ? module.log_analytics_workspace[0].resource_id : null)
   log_analytics_workspace_name = try(var.law_definition.name, null) != null ? var.law_definition.name : (var.name_prefix != null ? "${var.name_prefix}-law" : "ai-alz-law")
-  app_insights_diagnostic_settings = !var.app_insights_definition.enable_diagnostic_settings ? {} : (length(var.app_insights_definition.diagnostic_settings) > 0 ? var.app_insights_definition.diagnostic_settings : {
+  app_insights_diagnostic_settings = !var.app_insights_definition.enable_diagnostic_settings ? {} : (length(var.app_insights_definition.diagnostic_settings) > 0 ? var.app_insights_definition.diagnostic_settings : tomap({
     sendToLogAnalytics = {
+      name                  = null
       workspace_resource_id = local.log_analytics_workspace_id
+      logs = toset([{
+        category       = null
+        category_group = "allLogs"
+        enabled        = true
+        retention_policy = {
+          days    = 0
+          enabled = false
+        }
+      }])
+      metrics = toset([{
+        category = "AllMetrics"
+        enabled  = true
+        retention_policy = {
+          days    = 0
+          enabled = false
+        }
+      }])
+      log_analytics_destination_type           = "Dedicated"
+      storage_account_resource_id              = null
+      event_hub_authorization_rule_resource_id = null
+      event_hub_name                           = null
+      marketplace_partner_resource_id          = null
     }
-  })
+  }))
   app_insights_location               = lower(var.location) == "westcentralus" ? "eastus" : var.location
   app_insights_name                   = try(var.app_insights_definition.name, null) != null ? var.app_insights_definition.name : (var.name_prefix != null ? "${var.name_prefix}-app-insights" : "ai-alz-app-insights-${random_string.name_suffix.result}")
   app_insights_resource_id            = var.app_insights_definition.resource_id != null ? var.app_insights_definition.resource_id : try(azapi_resource.application_insights[0].id, null)

--- a/locals.monitoring.tf
+++ b/locals.monitoring.tf
@@ -10,7 +10,15 @@ locals {
       workspace_resource_id = local.log_analytics_workspace_id
     }
   })
-  app_insights_location    = lower(var.location) == "westcentralus" ? "eastus" : var.location
-  app_insights_name        = try(var.app_insights_definition.name, null) != null ? var.app_insights_definition.name : (var.name_prefix != null ? "${var.name_prefix}-app-insights" : "ai-alz-app-insights-${random_string.name_suffix.result}")
-  app_insights_resource_id = var.app_insights_definition.resource_id != null ? var.app_insights_definition.resource_id : (length(module.application_insights) > 0 ? module.application_insights[0].resource_id : null)
+  app_insights_location               = lower(var.location) == "westcentralus" ? "eastus" : var.location
+  app_insights_name                   = try(var.app_insights_definition.name, null) != null ? var.app_insights_definition.name : (var.name_prefix != null ? "${var.name_prefix}-app-insights" : "ai-alz-app-insights-${random_string.name_suffix.result}")
+  app_insights_resource_id            = var.app_insights_definition.resource_id != null ? var.app_insights_definition.resource_id : try(azapi_resource.application_insights[0].id, null)
+  app_insights_named_role_assignments = { for key, assignment in var.app_insights_definition.role_assignments : key => assignment if !startswith(assignment.role_definition_id_or_name, "/") && !can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", assignment.role_definition_id_or_name)) }
+  app_insights_resolved_role_assignments = { for key, assignment in var.app_insights_definition.role_assignments : key => merge(assignment, {
+    role_definition_id = startswith(assignment.role_definition_id_or_name, "/") ? assignment.role_definition_id_or_name : (
+      can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", assignment.role_definition_id_or_name)) ?
+      "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/${assignment.role_definition_id_or_name}" :
+      data.azapi_resource_list.app_insights_role_definition[key].output.role_definition_id
+    )
+  }) }
 }

--- a/main.apim_apis.tf
+++ b/main.apim_apis.tf
@@ -14,7 +14,7 @@ resource "azapi_resource" "apim_backend_ai_foundry" {
 
   name      = "ai-foundry-backend"
   parent_id = module.apim[0].resource_id
-  type      = "Microsoft.ApiManagement/service/backends@2024-05-01"
+  type      = var.resource_types.apimanagement_service_backends
   body = {
     properties = {
       description = "Azure AI Foundry backend service"
@@ -28,9 +28,22 @@ resource "azapi_resource" "apim_backend_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_backends) > 0 ? var.ignore_body_changes.apimanagement_service_backends : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [time_sleep.apim_ready]
 }
@@ -40,7 +53,7 @@ resource "azapi_resource" "apim_api_ai_foundry" {
 
   name      = "azure-openai-api"
   parent_id = module.apim[0].resource_id
-  type      = "Microsoft.ApiManagement/service/apis@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis
   body = {
     properties = {
       description = "Sample API for Azure AI Foundry - validates APIM to AI Foundry connectivity"
@@ -60,9 +73,22 @@ resource "azapi_resource" "apim_api_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis) > 0 ? var.ignore_body_changes.apimanagement_service_apis : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [azapi_resource.apim_backend_ai_foundry]
 }
@@ -72,7 +98,7 @@ resource "azapi_resource" "apim_api_operation_chat_completions" {
 
   name      = "chat-completions"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/operations@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_operations
   body = {
     properties = {
       description = "Creates a completion for the chat message using a deployed model."
@@ -102,9 +128,22 @@ resource "azapi_resource" "apim_api_operation_chat_completions" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_operations) > 0 ? var.ignore_body_changes.apimanagement_service_apis_operations : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "apim_api_operation_list_models" {
@@ -112,7 +151,7 @@ resource "azapi_resource" "apim_api_operation_list_models" {
 
   name      = "list-models"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/operations@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_operations
   body = {
     properties = {
       description = "Lists the available models for the Azure OpenAI service."
@@ -134,9 +173,22 @@ resource "azapi_resource" "apim_api_operation_list_models" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_operations) > 0 ? var.ignore_body_changes.apimanagement_service_apis_operations : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "apim_api_policy_ai_foundry" {
@@ -144,7 +196,7 @@ resource "azapi_resource" "apim_api_policy_ai_foundry" {
 
   name      = "policy"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/policies@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_policies
   body = {
     properties = {
       format = "rawxml"
@@ -169,9 +221,22 @@ resource "azapi_resource" "apim_api_policy_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_policies) > 0 ? var.ignore_body_changes.apimanagement_service_apis_policies : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   lifecycle {
     ignore_changes = [body]

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -26,10 +26,24 @@ module "foundry_ptn" {
 resource "azapi_resource_action" "purge_ai_foundry" {
   count = var.ai_foundry_definition.purge_on_destroy ? 1 : 0
 
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${local.ai_foundry_name}"
-  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
+  method                 = "DELETE"
+  resource_id            = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${local.ai_foundry_name}"
+  type                   = var.resource_types.cognitiveservices_locations_resource_groups_deleted_accounts
+  headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  when                   = "destroy"
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/main.genai_services.tf
+++ b/main.genai_services.tf
@@ -99,14 +99,11 @@ module "cosmosdb" {
     }
   }
   public_network_access_enabled = var.genai_cosmosdb_definition.public_network_access_enabled
+  sql_databases                 = var.genai_cosmosdb_definition.sql_databases
   tags                          = merge(local.tags, var.genai_cosmosdb_definition.tags != null ? var.genai_cosmosdb_definition.tags : {})
 
   depends_on = [module.private_dns_zones, module.hub_vnet_peering]
 }
-
-#TODO:
-# Implement subservice passthrough in variables and here
-# removing for testing PE DNS zone strategy when platform flag is false
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
@@ -120,6 +117,7 @@ module "storage_account" {
   account_kind                        = var.genai_storage_account_definition.account_kind
   account_replication_type            = var.genai_storage_account_definition.account_replication_type
   account_tier                        = var.genai_storage_account_definition.account_tier
+  containers                          = var.genai_storage_account_definition.containers
   diagnostic_settings_storage_account = local.genai_storage_account_diagnostic_settings
   enable_telemetry                    = var.enable_telemetry
   local_user_enabled                  = false

--- a/main.knowledge_sources.tf
+++ b/main.knowledge_sources.tf
@@ -16,6 +16,7 @@ module "search_service" {
       private_dns_zone_resource_ids = var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? null : (!var.flag_platform_landing_zone ? [module.private_dns_zones.ai_search_zone.resource_id] : [local.private_dns_zones_existing.ai_search_zone.resource_id])
       subnet_resource_id            = local.subnet_ids["PrivateEndpointSubnet"]
     }
+
   }
   public_network_access_enabled = var.ks_ai_search_definition.public_network_access_enabled
   replica_count                 = var.ks_ai_search_definition.replica_count
@@ -23,6 +24,36 @@ module "search_service" {
   semantic_search_sku           = var.ks_ai_search_definition.semantic_search_sku
   sku                           = var.ks_ai_search_definition.sku
   tags                          = merge(local.tags, var.ks_ai_search_definition.tags != null ? var.ks_ai_search_definition.tags : {})
+
+  depends_on = [module.private_dns_zones, module.hub_vnet_peering]
+}
+
+module "speech_service" {
+  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
+  version = "0.11.1"
+  count   = var.ks_speech_service_definition.deploy ? 1 : 0
+
+  kind                  = "SpeechServices"
+  location              = local.ks_speech_service_location
+  name                  = local.ks_speech_service_name
+  parent_id             = azurerm_resource_group.this.id
+  sku_name              = var.ks_speech_service_definition.sku
+  custom_subdomain_name = local.ks_speech_service_name
+  diagnostic_settings   = local.ks_speech_diagnostic_settings
+  enable_telemetry      = var.enable_telemetry
+  local_auth_enabled    = var.ks_speech_service_definition.local_authentication_enabled
+  managed_identities    = { system_assigned = true }
+  network_acls          = { default_action = "Deny", bypass = "AzureServices" }
+  private_endpoints = {
+    primary = {
+      private_dns_zone_resource_ids = var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? [] : [!var.flag_platform_landing_zone ? module.private_dns_zones.ai_foundry_cognitive_services_zone.resource_id : local.private_dns_zones_existing.ai_foundry_cognitive_services_zone.resource_id]
+      subnet_resource_id            = local.subnet_ids["PrivateEndpointSubnet"]
+    }
+  }
+  private_endpoints_manage_dns_zone_group = !var.private_dns_zones.azure_policy_pe_zone_linking_enabled
+  public_network_access_enabled           = var.ks_speech_service_definition.public_network_access_enabled
+  role_assignments                        = local.ks_speech_role_assignments
+  tags                                    = merge(local.tags, var.ks_speech_service_definition.tags != null ? var.ks_speech_service_definition.tags : {})
 
   depends_on = [module.private_dns_zones, module.hub_vnet_peering]
 }

--- a/main.knowledge_sources.tf
+++ b/main.knowledge_sources.tf
@@ -28,34 +28,236 @@ module "search_service" {
   depends_on = [module.private_dns_zones, module.hub_vnet_peering]
 }
 
-module "speech_service" {
-  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
-  version = "0.11.1"
-  count   = var.ks_speech_service_definition.deploy ? 1 : 0
+data "azapi_resource_list" "ks_speech_role_definition" {
+  for_each = local.ks_speech_named_role_assignments
 
-  kind                  = "SpeechServices"
-  location              = local.ks_speech_service_location
-  name                  = local.ks_speech_service_name
-  parent_id             = azurerm_resource_group.this.id
-  sku_name              = var.ks_speech_service_definition.sku
-  custom_subdomain_name = local.ks_speech_service_name
-  diagnostic_settings   = local.ks_speech_diagnostic_settings
-  enable_telemetry      = var.enable_telemetry
-  local_auth_enabled    = var.ks_speech_service_definition.local_authentication_enabled
-  managed_identities    = { system_assigned = true }
-  network_acls          = { default_action = "Deny", bypass = "AzureServices" }
-  private_endpoints = {
-    primary = {
-      private_dns_zone_resource_ids = var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? [] : [!var.flag_platform_landing_zone ? module.private_dns_zones.ai_foundry_cognitive_services_zone.resource_id : local.private_dns_zones_existing.ai_foundry_cognitive_services_zone.resource_id]
-      subnet_resource_id            = local.subnet_ids["PrivateEndpointSubnet"]
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  query_parameters = {
+    "$filter" = ["roleName eq '${replace(each.value.role_definition_id_or_name, "'", "''")}'"]
+  }
+  type    = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = {
+    role_definition_id = "value[0].id"
+  }
+  retry = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      read = timeouts.value.read
     }
   }
-  private_endpoints_manage_dns_zone_group = !var.private_dns_zones.azure_policy_pe_zone_linking_enabled
-  public_network_access_enabled           = var.ks_speech_service_definition.public_network_access_enabled
-  role_assignments                        = local.ks_speech_role_assignments
-  tags                                    = merge(local.tags, var.ks_speech_service_definition.tags != null ? var.ks_speech_service_definition.tags : {})
+}
+
+resource "azapi_resource" "speech_service" {
+  count = var.ks_speech_service_definition.deploy ? 1 : 0
+
+  location  = local.ks_speech_service_location
+  name      = local.ks_speech_service_name
+  parent_id = azurerm_resource_group.this.id
+  type      = var.resource_types.cognitiveservices_accounts
+  body = {
+    kind = "SpeechServices"
+    sku = {
+      name = var.ks_speech_service_definition.sku
+    }
+    properties = {
+      customSubDomainName = local.ks_speech_service_name
+      disableLocalAuth    = !var.ks_speech_service_definition.local_authentication_enabled
+      networkAcls = {
+        bypass        = "AzureServices"
+        defaultAction = var.ks_speech_service_definition.public_network_access_enabled ? "Allow" : "Deny"
+      }
+      publicNetworkAccess = var.ks_speech_service_definition.public_network_access_enabled ? "Enabled" : "Disabled"
+    }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.cognitiveservices_accounts) > 0 ? var.ignore_body_changes.cognitiveservices_accounts : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = ["properties.endpoint", "identity.principalId"]
+  retry                  = var.retry
+  tags                   = merge(local.tags, var.ks_speech_service_definition.tags != null ? var.ks_speech_service_definition.tags : {})
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [module.private_dns_zones, module.hub_vnet_peering]
+}
+
+resource "azapi_resource" "speech_private_endpoint" {
+  count = var.ks_speech_service_definition.deploy && !var.ks_speech_service_definition.public_network_access_enabled ? 1 : 0
+
+  location  = local.ks_speech_service_location
+  name      = local.ks_speech_private_endpoint_name
+  parent_id = azurerm_resource_group.this.id
+  type      = var.resource_types.network_private_endpoints
+  body = {
+    properties = {
+      privateLinkServiceConnections = [{
+        name = "${local.ks_speech_service_name}-account"
+        properties = {
+          groupIds             = ["account"]
+          privateLinkServiceId = azapi_resource.speech_service[0].id
+        }
+      }]
+      subnet = {
+        id = local.subnet_ids["PrivateEndpointSubnet"]
+      }
+    }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints) > 0 ? var.ignore_body_changes.network_private_endpoints : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  tags                   = merge(local.tags, var.ks_speech_service_definition.tags != null ? var.ks_speech_service_definition.tags : {})
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [body.properties.customDnsConfigs]
+  }
+}
+
+resource "azapi_resource" "speech_private_dns_zone_group" {
+  count = var.ks_speech_service_definition.deploy && !var.ks_speech_service_definition.public_network_access_enabled && !var.private_dns_zones.azure_policy_pe_zone_linking_enabled ? 1 : 0
+
+  name      = "default"
+  parent_id = azapi_resource.speech_private_endpoint[0].id
+  type      = var.resource_types.network_private_endpoints_private_dns_zone_groups
+  body = {
+    properties = {
+      privateDnsZoneConfigs = [{
+        name = "cognitive-services"
+        properties = {
+          privateDnsZoneId = local.ks_speech_private_dns_zone_id
+        }
+      }]
+    }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups) > 0 ? var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azapi_resource" "speech_diagnostic_setting" {
+  for_each = var.ks_speech_service_definition.deploy ? local.ks_speech_diagnostic_settings : {}
+
+  name      = coalesce(each.value.name, "diag-${local.ks_speech_service_name}")
+  parent_id = azapi_resource.speech_service[0].id
+  type      = var.resource_types.insights_diagnostic_settings
+  body = {
+    properties = { for key, value in {
+      eventHubAuthorizationRuleId = each.value.event_hub_authorization_rule_resource_id
+      eventHubName                = each.value.event_hub_name
+      logAnalyticsDestinationType = each.value.log_analytics_destination_type
+      logs = concat(
+        [for category in each.value.log_categories : { category = category, enabled = true }],
+        [for group in each.value.log_groups : { categoryGroup = group, enabled = true }]
+      )
+      marketplacePartnerId = each.value.marketplace_partner_resource_id
+      metrics              = [for category in each.value.metric_categories : { category = category, enabled = true }]
+      storageAccountId     = each.value.storage_account_resource_id
+      workspaceId          = each.value.workspace_resource_id
+    } : key => value if value != null }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.insights_diagnostic_settings) > 0 ? var.ignore_body_changes.insights_diagnostic_settings : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azapi_resource" "speech_role_assignment" {
+  for_each = var.ks_speech_service_definition.deploy ? local.ks_speech_resolved_role_assignments : {}
+
+  name      = uuidv5("url", "${azapi_resource.speech_service[0].id}|${each.value.principal_id}|${each.value.role_definition_id}")
+  parent_id = azapi_resource.speech_service[0].id
+  type      = var.resource_types.authorization_role_assignments
+  body = {
+    properties = { for key, value in {
+      condition                          = try(each.value.condition, null)
+      conditionVersion                   = try(each.value.condition_version, null)
+      delegatedManagedIdentityResourceId = try(each.value.delegated_managed_identity_resource_id, null)
+      description                        = try(each.value.description, null)
+      principalId                        = each.value.principal_id
+      principalType                      = try(each.value.principal_type, null)
+      roleDefinitionId                   = each.value.role_definition_id
+    } : key => value if value != null }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "bing_grounding" {
@@ -64,7 +266,7 @@ resource "azapi_resource" "bing_grounding" {
   location  = "global"
   name      = local.ks_bing_grounding_name
   parent_id = azurerm_resource_group.this.id
-  type      = "Microsoft.Bing/accounts@2025-05-01-preview"
+  type      = var.resource_types.bing_accounts
   body = {
     kind = "Bing.Grounding"
     sku = {
@@ -73,10 +275,24 @@ resource "azapi_resource" "bing_grounding" {
   }
   create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes       = length(var.ignore_body_changes.bing_accounts) > 0 ? var.ignore_body_changes.bing_accounts : null
   read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values    = []
+  retry                     = var.retry
   schema_validation_enabled = false
   tags                      = merge(local.tags, var.ks_bing_grounding_definition.tags != null ? var.ks_bing_grounding_definition.tags : {})
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   # The Microsoft.Bing/accounts resource provider normalizes tag keys by
   # lower-casing the first character (e.g. "SecurityControl" -> "securityControl"),

--- a/main.monitoring.tf
+++ b/main.monitoring.tf
@@ -11,3 +11,61 @@ module "log_analytics_workspace" {
   log_analytics_workspace_sku               = var.law_definition.sku
   tags                                      = merge(local.tags, var.law_definition.tags != null ? var.law_definition.tags : {})
 }
+
+data "azapi_resource" "existing_application_insights" {
+  count = var.app_insights_definition.resource_id != null && var.law_definition.resource_id != null && !var.app_insights_definition.allow_mixed_workspaces ? 1 : 0
+
+  resource_id            = var.app_insights_definition.resource_id
+  type                   = "Microsoft.Insights/components@2020-02-02"
+  response_export_values = ["properties.WorkspaceResourceId"]
+}
+
+resource "terraform_data" "observability_contract" {
+  lifecycle {
+    precondition {
+      condition     = !var.app_insights_definition.deploy || var.app_insights_definition.resource_id != null || var.law_definition.deploy || var.law_definition.resource_id != null
+      error_message = "Application Insights creation requires a created or existing Log Analytics workspace."
+    }
+    precondition {
+      condition     = var.app_insights_definition.resource_id == null || var.law_definition.resource_id != null || var.app_insights_definition.allow_mixed_workspaces
+      error_message = "Reusing Application Insights requires `law_definition.resource_id` unless `app_insights_definition.allow_mixed_workspaces` is true."
+    }
+    precondition {
+      condition = (
+        var.app_insights_definition.resource_id == null ||
+        var.law_definition.resource_id == null ||
+        var.app_insights_definition.allow_mixed_workspaces ||
+        try(
+          trimsuffix(lower(data.azapi_resource.existing_application_insights[0].output.properties.WorkspaceResourceId), "/") ==
+          trimsuffix(lower(var.law_definition.resource_id), "/"),
+          false
+        )
+      )
+      error_message = "The existing Application Insights component must use `law_definition.resource_id`; set `app_insights_definition.allow_mixed_workspaces` to true only for an intentional mixed-workspace deployment."
+    }
+  }
+}
+
+module "application_insights" {
+  source  = "Azure/avm-res-insights-component/azurerm"
+  version = "0.4.0"
+  count   = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? 1 : 0
+
+  location                      = local.app_insights_location
+  name                          = local.app_insights_name
+  resource_group_name           = azurerm_resource_group.this.name
+  workspace_id                  = local.log_analytics_workspace_id
+  application_type              = var.app_insights_definition.application_type
+  daily_data_cap_in_gb          = var.app_insights_definition.daily_data_cap_in_gb
+  diagnostic_settings           = local.app_insights_diagnostic_settings
+  disable_ip_masking            = var.app_insights_definition.disable_ip_masking
+  enable_telemetry              = var.enable_telemetry
+  internet_ingestion_enabled    = var.app_insights_definition.internet_ingestion_enabled
+  internet_query_enabled        = var.app_insights_definition.internet_query_enabled
+  local_authentication_disabled = var.app_insights_definition.local_authentication_disabled
+  retention_in_days             = var.app_insights_definition.retention_in_days
+  role_assignments              = var.app_insights_definition.role_assignments
+  tags                          = merge(local.tags, var.app_insights_definition.tags != null ? var.app_insights_definition.tags : {})
+
+  depends_on = [terraform_data.observability_contract]
+}

--- a/main.monitoring.tf
+++ b/main.monitoring.tf
@@ -20,6 +20,29 @@ data "azapi_resource" "existing_application_insights" {
   response_export_values = ["properties.WorkspaceResourceId"]
 }
 
+data "azapi_resource_list" "app_insights_role_definition" {
+  for_each = local.app_insights_named_role_assignments
+
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  query_parameters = {
+    "$filter" = ["roleName eq '${replace(each.value.role_definition_id_or_name, "'", "''")}'"]
+  }
+  type    = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = {
+    role_definition_id = "value[0].id"
+  }
+  retry = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      read = timeouts.value.read
+    }
+  }
+}
+
 resource "terraform_data" "observability_contract" {
   lifecycle {
     precondition {
@@ -46,26 +69,166 @@ resource "terraform_data" "observability_contract" {
   }
 }
 
-module "application_insights" {
-  source  = "Azure/avm-res-insights-component/azurerm"
-  version = "0.4.0"
-  count   = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? 1 : 0
+resource "azapi_resource" "application_insights" {
+  count = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? 1 : 0
 
-  location                      = local.app_insights_location
-  name                          = local.app_insights_name
-  resource_group_name           = azurerm_resource_group.this.name
-  workspace_id                  = local.log_analytics_workspace_id
-  application_type              = var.app_insights_definition.application_type
-  daily_data_cap_in_gb          = var.app_insights_definition.daily_data_cap_in_gb
-  diagnostic_settings           = local.app_insights_diagnostic_settings
-  disable_ip_masking            = var.app_insights_definition.disable_ip_masking
-  enable_telemetry              = var.enable_telemetry
-  internet_ingestion_enabled    = var.app_insights_definition.internet_ingestion_enabled
-  internet_query_enabled        = var.app_insights_definition.internet_query_enabled
-  local_authentication_disabled = var.app_insights_definition.local_authentication_disabled
-  retention_in_days             = var.app_insights_definition.retention_in_days
-  role_assignments              = var.app_insights_definition.role_assignments
-  tags                          = merge(local.tags, var.app_insights_definition.tags != null ? var.app_insights_definition.tags : {})
+  location  = local.app_insights_location
+  name      = local.app_insights_name
+  parent_id = azurerm_resource_group.this.id
+  type      = var.resource_types.insights_components
+  body = {
+    kind = "web"
+    properties = {
+      Application_Type                = var.app_insights_definition.application_type
+      DisableIpMasking                = var.app_insights_definition.disable_ip_masking
+      DisableLocalAuth                = var.app_insights_definition.local_authentication_disabled
+      Flow_Type                       = "Bluefield"
+      Request_Source                  = "rest"
+      RetentionInDays                 = var.app_insights_definition.retention_in_days
+      WorkspaceResourceId             = local.log_analytics_workspace_id
+      publicNetworkAccessForIngestion = var.app_insights_definition.internet_ingestion_enabled ? "Enabled" : "Disabled"
+      publicNetworkAccessForQuery     = var.app_insights_definition.internet_query_enabled ? "Enabled" : "Disabled"
+    }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.insights_components) > 0 ? var.ignore_body_changes.insights_components : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = ["properties.WorkspaceResourceId"]
+  retry                  = var.retry
+  tags                   = merge(local.tags, var.app_insights_definition.tags != null ? var.app_insights_definition.tags : {})
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [terraform_data.observability_contract]
+}
+
+resource "azapi_resource_action" "application_insights_daily_cap" {
+  count = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? 1 : 0
+
+  action      = "currentbillingfeatures"
+  method      = "PUT"
+  resource_id = azapi_resource.application_insights[0].id
+  type        = var.resource_types.insights_components_currentbillingfeatures
+  body = {
+    CurrentBillingFeatures = ["Basic"]
+    DataVolumeCap = {
+      Cap                            = var.app_insights_definition.daily_data_cap_in_gb
+      StopSendNotificationWhenHitCap = false
+    }
+  }
+  headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azapi_resource" "application_insights_diagnostic_setting" {
+  for_each = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? local.app_insights_diagnostic_settings : {}
+
+  name      = coalesce(try(each.value.name, null), "diag-${local.app_insights_name}")
+  parent_id = azapi_resource.application_insights[0].id
+  type      = var.resource_types.insights_diagnostic_settings
+  body = {
+    properties = { for key, value in {
+      eventHubAuthorizationRuleId = try(each.value.event_hub_authorization_rule_resource_id, null)
+      eventHubName                = try(each.value.event_hub_name, null)
+      logAnalyticsDestinationType = try(each.value.log_analytics_destination_type, "Dedicated")
+      logs = [for log in try(each.value.logs, []) : { for log_key, log_value in {
+        category      = log.category
+        categoryGroup = log.category_group
+        enabled       = log.enabled
+        retentionPolicy = {
+          days    = log.retention_policy.days
+          enabled = log.retention_policy.enabled
+        }
+      } : log_key => log_value if log_value != null }]
+      marketplacePartnerId = try(each.value.marketplace_partner_resource_id, null)
+      metrics = [for metric in try(each.value.metrics, []) : { for metric_key, metric_value in {
+        category = metric.category
+        enabled  = metric.enabled
+        retentionPolicy = {
+          days    = metric.retention_policy.days
+          enabled = metric.retention_policy.enabled
+        }
+      } : metric_key => metric_value if metric_value != null }]
+      storageAccountId = try(each.value.storage_account_resource_id, null)
+      workspaceId      = each.value.workspace_resource_id
+    } : key => value if value != null }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.insights_diagnostic_settings) > 0 ? var.ignore_body_changes.insights_diagnostic_settings : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azapi_resource" "application_insights_role_assignment" {
+  for_each = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? local.app_insights_resolved_role_assignments : {}
+
+  name      = uuidv5("url", "${azapi_resource.application_insights[0].id}|${each.value.principal_id}|${each.value.role_definition_id}")
+  parent_id = azapi_resource.application_insights[0].id
+  type      = var.resource_types.authorization_role_assignments
+  body = {
+    properties = { for key, value in {
+      condition                          = each.value.condition
+      conditionVersion                   = each.value.condition_version
+      delegatedManagedIdentityResourceId = each.value.delegated_managed_identity_resource_id
+      description                        = each.value.description
+      principalId                        = each.value.principal_id
+      principalType                      = each.value.principal_type
+      roleDefinitionId                   = each.value.role_definition_id
+    } : key => value if value != null }
+  }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/outputs.monitoring.tf
+++ b/outputs.monitoring.tf
@@ -1,3 +1,13 @@
+output "application_insights_name" {
+  description = "The name of the created Application Insights component, or null when an existing component is reused."
+  value       = var.app_insights_definition.resource_id == null && var.app_insights_definition.deploy ? local.app_insights_name : null
+}
+
+output "application_insights_resource_id" {
+  description = "The resource ID of the created or reused Application Insights component. No connection string or instrumentation key is exposed."
+  value       = local.app_insights_resource_id
+}
+
 output "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics Workspace used for monitoring."
   value       = local.log_analytics_workspace_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,26 @@ output "apim" {
   value       = try(module.apim[0], null)
 }
 
+output "data_ai_services" {
+  description = "Non-secret resource and runtime-discovery values for the Data & AI services parity contract."
+  value = {
+    key_vault_resource_id       = try(module.avm_res_keyvault_vault[0].resource_id, null)
+    cosmos_db_resource_id       = try(module.cosmosdb[0].resource_id, null)
+    cosmos_sql_databases        = var.genai_cosmosdb_definition.deploy ? { for key, database in var.genai_cosmosdb_definition.sql_databases : key => { name = database.name, containers = { for container_key, container in database.containers : container_key => { name = container.name, partition_key_paths = container.partition_key_paths } } } } : {}
+    storage_account_resource_id = try(module.storage_account[0].resource_id, null)
+    storage_containers          = var.genai_storage_account_definition.deploy ? { for key, container in var.genai_storage_account_definition.containers : key => container.name } : {}
+    application_insights_id     = local.app_insights_resource_id
+    log_analytics_workspace_id  = local.log_analytics_workspace_id
+    search_service_resource_id  = try(module.search_service[0].resource_id, null)
+    bing_grounding_resource_id  = try(azapi_resource.bing_grounding[0].id, null)
+    speech_service_resource_id  = try(module.speech_service[0].resource_id, null)
+    speech_service_name         = try(module.speech_service[0].name, null)
+    speech_service_location     = var.ks_speech_service_definition.deploy ? local.ks_speech_service_location : null
+    speech_service_endpoint     = try(module.speech_service[0].endpoint, null)
+    speech_service_principal_id = try(module.speech_service[0].system_assigned_mi_principal_id, null)
+  }
+}
+
 #TODO: determine what a good set of outpus should be and update.
 output "resource_id" {
   description = "Future resource ID output for the LZA."

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,11 +15,11 @@ output "data_ai_services" {
     log_analytics_workspace_id  = local.log_analytics_workspace_id
     search_service_resource_id  = try(module.search_service[0].resource_id, null)
     bing_grounding_resource_id  = try(azapi_resource.bing_grounding[0].id, null)
-    speech_service_resource_id  = try(module.speech_service[0].resource_id, null)
-    speech_service_name         = try(module.speech_service[0].name, null)
+    speech_service_resource_id  = try(azapi_resource.speech_service[0].id, null)
+    speech_service_name         = var.ks_speech_service_definition.deploy ? local.ks_speech_service_name : null
     speech_service_location     = var.ks_speech_service_definition.deploy ? local.ks_speech_service_location : null
-    speech_service_endpoint     = try(module.speech_service[0].endpoint, null)
-    speech_service_principal_id = try(module.speech_service[0].system_assigned_mi_principal_id, null)
+    speech_service_endpoint     = try(azapi_resource.speech_service[0].output.properties.endpoint, null)
+    speech_service_principal_id = try(azapi_resource.speech_service[0].output.identity.principalId, null)
   }
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.12"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/tests/unit/data_ai_services.tftest.hcl
+++ b/tests/unit/data_ai_services.tftest.hcl
@@ -1,0 +1,159 @@
+# AzAPI remains real because Terraform mock providers cannot expose ephemeral
+# resource types used by existing module dependencies:
+# https://github.com/hashicorp/terraform/issues/38608
+mock_provider "azurerm" {
+  mock_data "azurerm_client_config" {
+    defaults = {
+      client_id       = "00000000-0000-0000-0000-000000000001"
+      object_id       = "00000000-0000-0000-0000-000000000002"
+      subscription_id = "00000000-0000-0000-0000-000000000003"
+      tenant_id       = "00000000-0000-0000-0000-000000000004"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+override_module {
+  target = module.container_apps_managed_environment
+}
+
+override_module {
+  target = module.foundry_ptn
+
+  outputs = {
+    ai_foundry_name = "mock-foundry"
+  }
+}
+
+variables {
+  app_gateway_definition = {
+    backend_address_pools = {}
+    backend_http_settings = {}
+    frontend_ports        = {}
+    http_listeners        = {}
+    request_routing_rules = {}
+  }
+  enable_telemetry           = false
+  flag_platform_landing_zone = false
+  location                   = "eastus"
+  name_prefix                = "parity"
+  resource_group_name        = "rg-data-ai-parity-test"
+  vnet_definition            = {}
+}
+
+run "data_services_defaults" {
+  command = plan
+
+  assert {
+    condition     = output.data_ai_services.cosmos_sql_databases.application.name == "cosmosdb"
+    error_message = "The default Cosmos DB SQL database contract must be present."
+  }
+
+  assert {
+    condition     = length(output.data_ai_services.cosmos_sql_databases.application.containers.conversations.partition_key_paths) == 1 && output.data_ai_services.cosmos_sql_databases.application.containers.conversations.partition_key_paths[0] == "/principal_id"
+    error_message = "The conversations container must retain the /principal_id partition key."
+  }
+
+  assert {
+    condition     = output.data_ai_services.storage_containers.documents == "documents"
+    error_message = "The default private documents container must be present."
+  }
+}
+
+run "application_insights_and_speech_opt_in" {
+  command = plan
+
+  variables {
+    app_insights_definition = {
+      deploy = true
+    }
+    ks_speech_service_definition = {
+      deploy = true
+    }
+  }
+
+  assert {
+    condition     = output.application_insights_name == "parity-app-insights"
+    error_message = "Application Insights must use the deterministic prefixed name."
+  }
+
+  assert {
+    condition     = output.data_ai_services.speech_service_location == "eastus"
+    error_message = "Speech must inherit the landing-zone location by default."
+  }
+}
+
+run "speech_f0_is_rejected_for_private_networking" {
+  command = plan
+
+  variables {
+    ks_speech_service_definition = {
+      deploy = true
+      sku    = "F0"
+    }
+  }
+
+  expect_failures = [
+    var.ks_speech_service_definition,
+  ]
+}
+
+run "speech_invalid_sku_is_rejected" {
+  command = plan
+
+  variables {
+    ks_speech_service_definition = {
+      sku = "S1"
+    }
+  }
+
+  expect_failures = [
+    var.ks_speech_service_definition,
+  ]
+}
+
+run "mixed_observability_requires_opt_in" {
+  command = plan
+
+  variables {
+    app_insights_definition = {
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/central-observability/providers/Microsoft.Insights/components/existing-app-insights"
+    }
+  }
+
+  expect_failures = [
+    terraform_data.observability_contract,
+  ]
+}
+
+run "existing_application_insights_workspace_must_match" {
+  command = plan
+
+  override_data {
+    target = data.azapi_resource.existing_application_insights[0]
+
+    values = {
+      output = {
+        properties = {
+          WorkspaceResourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+        }
+      }
+    }
+  }
+
+  variables {
+    app_insights_definition = {
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/central-observability/providers/Microsoft.Insights/components/existing-app-insights"
+    }
+    law_definition = {
+      deploy      = false
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-b"
+    }
+  }
+
+  expect_failures = [
+    terraform_data.observability_contract,
+  ]
+}

--- a/tests/unit/data_ai_services.tftest.hcl
+++ b/tests/unit/data_ai_services.tftest.hcl
@@ -229,8 +229,77 @@ run "application_insights_diagnostics_are_explicit" {
   }
 
   assert {
-    condition     = length(azapi_resource.application_insights_diagnostic_setting) == 1 && values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.workspaceId == "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
-    error_message = "Application Insights diagnostics must target the effective Log Analytics workspace when enabled."
+    condition = (
+      length(azapi_resource.application_insights_diagnostic_setting) == 1 &&
+      values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.workspaceId == "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a" &&
+      values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.logs == [{
+        categoryGroup = "allLogs"
+        enabled       = true
+        retentionPolicy = {
+          days    = 0
+          enabled = false
+        }
+      }] &&
+      values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.metrics == [{
+        category = "AllMetrics"
+        enabled  = true
+        retentionPolicy = {
+          days    = 0
+          enabled = false
+        }
+      }]
+    )
+    error_message = "Automatic Application Insights diagnostics must target the effective workspace and collect allLogs and AllMetrics."
+  }
+}
+
+run "application_insights_explicit_diagnostics_are_preserved" {
+  command = plan
+
+  variables {
+    app_insights_definition = {
+      deploy                     = true
+      enable_diagnostic_settings = true
+      diagnostic_settings = {
+        requests_only = {
+          workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+          logs = [{
+            category = "AppRequests"
+          }]
+          metrics = [{
+            category = "AllMetrics"
+            enabled  = false
+          }]
+        }
+      }
+    }
+    law_definition = {
+      deploy      = false
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+    }
+  }
+
+  assert {
+    condition = (
+      length(azapi_resource.application_insights_diagnostic_setting) == 1 &&
+      values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.logs == [{
+        category = "AppRequests"
+        enabled  = true
+        retentionPolicy = {
+          days    = 0
+          enabled = false
+        }
+      }] &&
+      values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.metrics == [{
+        category = "AllMetrics"
+        enabled  = false
+        retentionPolicy = {
+          days    = 0
+          enabled = false
+        }
+      }]
+    )
+    error_message = "Explicit Application Insights diagnostic categories and enabled states must remain unchanged."
   }
 }
 

--- a/tests/unit/data_ai_services.tftest.hcl
+++ b/tests/unit/data_ai_services.tftest.hcl
@@ -43,22 +43,61 @@ variables {
   vnet_definition            = {}
 }
 
-run "data_services_defaults" {
+run "data_services_defaults_are_upgrade_safe" {
   command = plan
 
   assert {
-    condition     = output.data_ai_services.cosmos_sql_databases.application.name == "cosmosdb"
-    error_message = "The default Cosmos DB SQL database contract must be present."
+    condition     = output.data_ai_services.cosmos_sql_databases == {}
+    error_message = "Cosmos DB SQL databases must default to empty so upgrades do not create child resources."
   }
 
   assert {
-    condition     = length(output.data_ai_services.cosmos_sql_databases.application.containers.conversations.partition_key_paths) == 1 && output.data_ai_services.cosmos_sql_databases.application.containers.conversations.partition_key_paths[0] == "/principal_id"
-    error_message = "The conversations container must retain the /principal_id partition key."
+    condition     = output.data_ai_services.storage_containers == {}
+    error_message = "Storage containers must default to empty so upgrades do not create child resources."
+  }
+}
+
+run "data_services_children_are_explicitly_opted_in" {
+  command = plan
+
+  variables {
+    genai_cosmosdb_definition = {
+      sql_databases = {
+        application = {
+          name = "cosmosdb"
+          containers = {
+            conversations = {
+              name                = "conversations"
+              partition_key_paths = ["/principal_id"]
+              default_ttl         = -1
+            }
+          }
+        }
+      }
+    }
+    genai_storage_account_definition = {
+      containers = {
+        documents = {
+          name          = "documents"
+          public_access = "None"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.data_ai_services.cosmos_sql_databases.application.name == "cosmosdb"
+    error_message = "The explicit Cosmos DB parity preset must create the application database."
+  }
+
+  assert {
+    condition     = output.data_ai_services.cosmos_sql_databases.application.containers.conversations.partition_key_paths == tolist(["/principal_id"])
+    error_message = "The explicit conversations container must retain the /principal_id partition key."
   }
 
   assert {
     condition     = output.data_ai_services.storage_containers.documents == "documents"
-    error_message = "The default private documents container must be present."
+    error_message = "The explicit private documents container must be present."
   }
 }
 
@@ -72,6 +111,13 @@ run "application_insights_and_speech_opt_in" {
     ks_speech_service_definition = {
       deploy = true
     }
+    law_definition = {
+      deploy      = false
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+    }
+    private_dns_zones = {
+      azure_policy_pe_zone_linking_enabled = false
+    }
   }
 
   assert {
@@ -82,6 +128,109 @@ run "application_insights_and_speech_opt_in" {
   assert {
     condition     = output.data_ai_services.speech_service_location == "eastus"
     error_message = "Speech must inherit the landing-zone location by default."
+  }
+
+  assert {
+    condition = (
+      azapi_resource.application_insights[0].body.properties.WorkspaceResourceId == "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a" &&
+      azapi_resource.application_insights[0].body.properties.DisableLocalAuth &&
+      azapi_resource_action.application_insights_daily_cap[0].body.DataVolumeCap.Cap == 100
+    )
+    error_message = "Application Insights must remain workspace-associated, local-auth disabled, and daily-cap managed."
+  }
+
+  assert {
+    condition = (
+      azapi_resource.speech_service[0].body.properties.publicNetworkAccess == "Disabled" &&
+      azapi_resource.speech_service[0].body.properties.networkAcls.defaultAction == "Deny" &&
+      azapi_resource.speech_service[0].body.properties.disableLocalAuth &&
+      azapi_resource.speech_service[0].identity[0].type == "SystemAssigned"
+    )
+    error_message = "Network-isolated Speech must disable public/local access, deny by default, and use a system identity."
+  }
+
+  assert {
+    condition = (
+      length(azapi_resource.speech_private_endpoint) == 1 &&
+      azapi_resource.speech_private_endpoint[0].body.properties.privateLinkServiceConnections[0].properties.groupIds == ["account"] &&
+      length(azapi_resource.speech_private_dns_zone_group) == 1 &&
+      azapi_resource.speech_private_dns_zone_group[0].body.properties.privateDnsZoneConfigs[0].name == "cognitive-services"
+    )
+    error_message = "Network-isolated Speech must create the account private endpoint and Cognitive Services DNS zone group."
+  }
+
+  assert {
+    condition     = length(azapi_resource.speech_diagnostic_setting) == 1 && values(azapi_resource.speech_diagnostic_setting)[0].body.properties.workspaceId == "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+    error_message = "Speech diagnostics must target the effective Log Analytics workspace."
+  }
+
+  assert {
+    condition     = length(azapi_resource.speech_role_assignment) == 0
+    error_message = "Deployment-principal Speech RBAC must remain opt-in."
+  }
+}
+
+run "speech_standard_access_has_no_private_endpoint" {
+  command = plan
+
+  variables {
+    ks_speech_service_definition = {
+      deploy                           = true
+      enable_diagnostic_settings       = false
+      public_network_access_enabled    = true
+      assign_deployment_principal_rbac = false
+    }
+  }
+
+  assert {
+    condition = (
+      azapi_resource.speech_service[0].body.properties.publicNetworkAccess == "Enabled" &&
+      azapi_resource.speech_service[0].body.properties.networkAcls.defaultAction == "Allow" &&
+      length(azapi_resource.speech_private_endpoint) == 0 &&
+      length(azapi_resource.speech_private_dns_zone_group) == 0
+    )
+    error_message = "Standard Speech must enable public access and omit private endpoint/DNS resources."
+  }
+}
+
+run "speech_deployment_principal_rbac_is_explicit" {
+  command = plan
+
+  variables {
+    ks_speech_service_definition = {
+      deploy                           = true
+      enable_diagnostic_settings       = false
+      public_network_access_enabled    = true
+      assign_deployment_principal_rbac = true
+    }
+  }
+
+  assert {
+    condition = toset([for assignment in values(azapi_resource.speech_role_assignment) : assignment.body.properties.roleDefinitionId]) == toset([
+      "/subscriptions/00000000-0000-0000-0000-000000000003/providers/Microsoft.Authorization/roleDefinitions/25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+      "/subscriptions/00000000-0000-0000-0000-000000000003/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908",
+    ])
+    error_message = "Explicit deployment-principal RBAC must assign only Cognitive Services Contributor and User."
+  }
+}
+
+run "application_insights_diagnostics_are_explicit" {
+  command = plan
+
+  variables {
+    app_insights_definition = {
+      deploy                     = true
+      enable_diagnostic_settings = true
+    }
+    law_definition = {
+      deploy      = false
+      resource_id = "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+    }
+  }
+
+  assert {
+    condition     = length(azapi_resource.application_insights_diagnostic_setting) == 1 && values(azapi_resource.application_insights_diagnostic_setting)[0].body.properties.workspaceId == "/subscriptions/00000000-0000-0000-0000-000000000003/resourceGroups/central-observability/providers/Microsoft.OperationalInsights/workspaces/workspace-a"
+    error_message = "Application Insights diagnostics must target the effective Log Analytics workspace when enabled."
   }
 }
 

--- a/variables.genai_services.tf
+++ b/variables.genai_services.tf
@@ -198,6 +198,97 @@ variable "genai_cosmosdb_definition" {
       exposed_headers    = set(string)
       max_age_in_seconds = optional(number, null)
     }), null)
+    sql_databases = optional(map(object({
+      name       = string
+      throughput = optional(number, null)
+      autoscale_settings = optional(object({
+        max_throughput = number
+      }), null)
+      containers = optional(map(object({
+        name                   = string
+        partition_key_paths    = list(string)
+        partition_key_version  = optional(number, 2)
+        throughput             = optional(number, null)
+        default_ttl            = optional(number, null)
+        analytical_storage_ttl = optional(number, null)
+        unique_keys = optional(list(object({
+          paths = set(string)
+        })), [])
+        autoscale_settings = optional(object({
+          max_throughput = number
+        }), null)
+        conflict_resolution_policy = optional(object({
+          mode                          = string
+          conflict_resolution_path      = optional(string, null)
+          conflict_resolution_procedure = optional(string, null)
+        }), null)
+        indexing_policy = optional(object({
+          indexing_mode = string
+          included_paths = optional(set(object({
+            path = string
+          })), [])
+          excluded_paths = optional(set(object({
+            path = string
+          })), [])
+          composite_indexes = optional(set(object({
+            indexes = set(object({
+              path  = string
+              order = string
+            }))
+          })), [])
+          spatial_indexes = optional(set(object({
+            path = string
+          })), [])
+        }), null)
+      })), {})
+      })), {
+      application = {
+        name = "cosmosdb"
+        containers = {
+          conversations = {
+            name                = "conversations"
+            partition_key_paths = ["/principal_id"]
+            default_ttl         = -1
+            indexing_policy = {
+              indexing_mode = "consistent"
+              included_paths = [{
+                path = "/*"
+              }]
+              composite_indexes = [
+                {
+                  indexes = [
+                    {
+                      path  = "/isDeleted"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/_ts"
+                      order = "Descending"
+                    }
+                  ]
+                },
+                {
+                  indexes = [
+                    {
+                      path  = "/isDeleted"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/name"
+                      order = "Ascending"
+                    },
+                    {
+                      path  = "/_ts"
+                      order = "Descending"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
     tags = optional(map(string))
   })
   default     = {}
@@ -250,6 +341,21 @@ Configuration object for the Azure Cosmos DB account to be created for GenAI ser
   - `allowed_origins` - Set of allowed origins.
   - `exposed_headers` - Set of exposed headers.
   - `max_age_in_seconds` - (Optional) Maximum age in seconds for CORS.
+- `sql_databases` - (Optional) SQL databases and containers to create. The default creates the `cosmosdb` database and the `conversations` container with partition key `/principal_id`, infinite TTL, and the source landing zone's composite indexes.
+  - `name` - Database name.
+  - `throughput` - (Optional) Manual database throughput.
+  - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
+  - `containers` - (Optional) SQL containers keyed by an arbitrary map key.
+    - `name` - Container name.
+    - `partition_key_paths` - Partition key paths.
+    - `partition_key_version` - (Optional) Partition key version. Default is 2.
+    - `throughput` - (Optional) Manual container throughput.
+    - `default_ttl` - (Optional) Default time to live. The parity default is -1.
+    - `analytical_storage_ttl` - (Optional) Analytical-store time to live.
+    - `unique_keys` - (Optional) Unique key paths.
+    - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
+    - `conflict_resolution_policy` - (Optional) Conflict-resolution mode and path or procedure.
+    - `indexing_policy` - (Optional) Indexing mode, included/excluded paths, composite indexes, and spatial indexes.
 - `tags` - (Optional) Map of tags to assign to the Cosmos DB account.
 DESCRIPTION
 }
@@ -365,10 +471,40 @@ variable "genai_storage_account_definition" {
       delegated_managed_identity_resource_id = optional(string, null)
       principal_type                         = optional(string, null)
     })), {})
+    containers = optional(map(object({
+      name                           = string
+      public_access                  = optional(string, "None")
+      metadata                       = optional(map(string))
+      default_encryption_scope       = optional(string)
+      deny_encryption_scope_override = optional(bool)
+      enable_nfs_v3_all_squash       = optional(bool)
+      enable_nfs_v3_root_squash      = optional(bool)
+      immutable_storage_with_versioning = optional(object({
+        enabled = bool
+      }))
+      role_assignments = optional(map(object({
+        role_definition_id_or_name             = string
+        principal_id                           = string
+        principal_type                         = optional(string, null)
+        description                            = optional(string, null)
+        skip_service_principal_aad_check       = optional(bool, false)
+        condition                              = optional(string, null)
+        condition_version                      = optional(string, null)
+        delegated_managed_identity_resource_id = optional(string, null)
+      })), {})
+      timeouts = optional(object({
+        create = optional(string)
+        delete = optional(string)
+        read   = optional(string)
+        update = optional(string)
+      }))
+      })), {
+      documents = {
+        name          = "documents"
+        public_access = "None"
+      }
+    })
     tags = optional(map(string))
-
-    #TODO:
-    # Implement subservice passthrough here
   })
   default     = {}
   description = <<DESCRIPTION
@@ -395,6 +531,17 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
+- `containers` - (Optional) Blob containers to create. The default creates a private `documents` container.
+  - `name` - Container name.
+  - `public_access` - (Optional) Public access level. Default is "None".
+  - `metadata` - (Optional) Container metadata.
+  - `default_encryption_scope` - (Optional) Default encryption scope.
+  - `deny_encryption_scope_override` - (Optional) Whether clients may override the encryption scope.
+  - `enable_nfs_v3_all_squash` - (Optional) Whether NFSv3 all squash is enabled.
+  - `enable_nfs_v3_root_squash` - (Optional) Whether NFSv3 root squash is enabled.
+  - `immutable_storage_with_versioning` - (Optional) Immutable storage configuration.
+  - `role_assignments` - (Optional) Container-scoped role assignments.
+  - `timeouts` - (Optional) Container operation timeouts.
 - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `role_definition_id_or_name` - The role definition ID or name to assign.
   - `principal_id` - The principal ID to assign the role to.

--- a/variables.genai_services.tf
+++ b/variables.genai_services.tf
@@ -241,54 +241,7 @@ variable "genai_cosmosdb_definition" {
           })), [])
         }), null)
       })), {})
-      })), {
-      application = {
-        name = "cosmosdb"
-        containers = {
-          conversations = {
-            name                = "conversations"
-            partition_key_paths = ["/principal_id"]
-            default_ttl         = -1
-            indexing_policy = {
-              indexing_mode = "consistent"
-              included_paths = [{
-                path = "/*"
-              }]
-              composite_indexes = [
-                {
-                  indexes = [
-                    {
-                      path  = "/isDeleted"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/_ts"
-                      order = "Descending"
-                    }
-                  ]
-                },
-                {
-                  indexes = [
-                    {
-                      path  = "/isDeleted"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/name"
-                      order = "Ascending"
-                    },
-                    {
-                      path  = "/_ts"
-                      order = "Descending"
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      }
-    })
+    })), {})
     tags = optional(map(string))
   })
   default     = {}
@@ -341,7 +294,7 @@ Configuration object for the Azure Cosmos DB account to be created for GenAI ser
   - `allowed_origins` - Set of allowed origins.
   - `exposed_headers` - Set of exposed headers.
   - `max_age_in_seconds` - (Optional) Maximum age in seconds for CORS.
-- `sql_databases` - (Optional) SQL databases and containers to create. The default creates the `cosmosdb` database and the `conversations` container with partition key `/principal_id`, infinite TTL, and the source landing zone's composite indexes.
+- `sql_databases` - (Optional) SQL databases and containers to create. Default is empty so an upgrade never creates or collides with child resources implicitly.
   - `name` - Database name.
   - `throughput` - (Optional) Manual database throughput.
   - `autoscale_settings.max_throughput` - (Optional) Maximum autoscale throughput.
@@ -498,12 +451,7 @@ variable "genai_storage_account_definition" {
         read   = optional(string)
         update = optional(string)
       }))
-      })), {
-      documents = {
-        name          = "documents"
-        public_access = "None"
-      }
-    })
+    })), {})
     tags = optional(map(string))
   })
   default     = {}
@@ -531,7 +479,7 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
 - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
 - `public_network_access_enabled` - (Optional) Whether public network access is enabled. Default is false.
 - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is true.
-- `containers` - (Optional) Blob containers to create. The default creates a private `documents` container.
+- `containers` - (Optional) Blob containers to create. Default is empty so an upgrade never creates or collides with child resources implicitly.
   - `name` - Container name.
   - `public_access` - (Optional) Public access level. Default is "None".
   - `metadata` - (Optional) Container metadata.

--- a/variables.knowledge_sources.tf
+++ b/variables.knowledge_sources.tf
@@ -96,3 +96,61 @@ Configuration object for the Bing Grounding service to be created as part of the
 - `tags` - (Optional) Map of tags to assign to the Bing Grounding service.
 DESCRIPTION
 }
+
+variable "ks_speech_service_definition" {
+  type = object({
+    deploy                           = optional(bool, false)
+    name                             = optional(string)
+    location                         = optional(string)
+    sku                              = optional(string, "S0")
+    public_network_access_enabled    = optional(bool, false)
+    local_authentication_enabled     = optional(bool, false)
+    assign_deployment_principal_rbac = optional(bool, true)
+    enable_diagnostic_settings       = optional(bool, true)
+    diagnostic_settings = optional(map(object({
+      name                                     = optional(string, null)
+      log_categories                           = optional(set(string), [])
+      log_groups                               = optional(set(string), ["allLogs"])
+      metric_categories                        = optional(set(string), ["AllMetrics"])
+      log_analytics_destination_type           = optional(string, "Dedicated")
+      workspace_resource_id                    = optional(string, null)
+      storage_account_resource_id              = optional(string, null)
+      event_hub_authorization_rule_resource_id = optional(string, null)
+      event_hub_name                           = optional(string, null)
+      marketplace_partner_resource_id          = optional(string, null)
+    })), {})
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    tags = optional(map(string))
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Configuration for an optional Azure AI Speech account.
+
+- `deploy` - (Optional) Deploy Speech. Default is false.
+- `name` - (Optional) Account and custom subdomain name.
+- `location` - (Optional) Azure region. Defaults to the landing-zone region.
+- `sku` - (Optional) Speech SKU. The network-isolated configuration requires "S0", which is the default.
+- `public_network_access_enabled` - (Optional) Enable public network access. Default is false.
+- `local_authentication_enabled` - (Optional) Enable key-based local authentication. Default is false.
+- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is true.
+- `enable_diagnostic_settings` - (Optional) Enable automatic diagnostics to the effective Log Analytics workspace. Default is true.
+- `diagnostic_settings` - (Optional) Explicit diagnostic settings, which take precedence over the automatic setting.
+- `role_assignments` - (Optional) Additional account-scoped role assignments for workload identities.
+- `tags` - (Optional) Account tags.
+DESCRIPTION
+  nullable    = false
+
+  validation {
+    condition     = var.ks_speech_service_definition.sku == "S0"
+    error_message = "`ks_speech_service_definition.sku` must be \"S0\" because Azure AI Speech private endpoints do not support the F0 tier."
+  }
+}

--- a/variables.knowledge_sources.tf
+++ b/variables.knowledge_sources.tf
@@ -105,7 +105,7 @@ variable "ks_speech_service_definition" {
     sku                              = optional(string, "S0")
     public_network_access_enabled    = optional(bool, false)
     local_authentication_enabled     = optional(bool, false)
-    assign_deployment_principal_rbac = optional(bool, true)
+    assign_deployment_principal_rbac = optional(bool, false)
     enable_diagnostic_settings       = optional(bool, true)
     diagnostic_settings = optional(map(object({
       name                                     = optional(string, null)
@@ -141,7 +141,7 @@ Configuration for an optional Azure AI Speech account.
 - `sku` - (Optional) Speech SKU. The network-isolated configuration requires "S0", which is the default.
 - `public_network_access_enabled` - (Optional) Enable public network access. Default is false.
 - `local_authentication_enabled` - (Optional) Enable key-based local authentication. Default is false.
-- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is true.
+- `assign_deployment_principal_rbac` - (Optional) Assign Cognitive Services Contributor and Cognitive Services User to the deployment principal. Default is false. Account creation and managed-identity authentication do not require these persistent data-plane roles; enable only when the deployment principal must perform post-deployment Cognitive Services operations.
 - `enable_diagnostic_settings` - (Optional) Enable automatic diagnostics to the effective Log Analytics workspace. Default is true.
 - `diagnostic_settings` - (Optional) Explicit diagnostic settings, which take precedence over the automatic setting.
 - `role_assignments` - (Optional) Additional account-scoped role assignments for workload identities.

--- a/variables.monitoring.tf
+++ b/variables.monitoring.tf
@@ -1,3 +1,83 @@
+variable "app_insights_definition" {
+  type = object({
+    deploy                        = optional(bool, false)
+    resource_id                   = optional(string)
+    name                          = optional(string)
+    application_type              = optional(string, "web")
+    daily_data_cap_in_gb          = optional(number, 100)
+    disable_ip_masking            = optional(bool, false)
+    internet_ingestion_enabled    = optional(bool, true)
+    internet_query_enabled        = optional(bool, true)
+    local_authentication_disabled = optional(bool, true)
+    retention_in_days             = optional(number, 90)
+    allow_mixed_workspaces        = optional(bool, false)
+    enable_diagnostic_settings    = optional(bool, false)
+    diagnostic_settings = optional(map(object({
+      name = optional(string, null)
+      logs = optional(set(object({
+        category       = optional(string, null)
+        category_group = optional(string, null)
+        enabled        = optional(bool, true)
+        retention_policy = optional(object({
+          days    = optional(number, 0)
+          enabled = optional(bool, false)
+        }), {})
+      })), [])
+      metrics = optional(set(object({
+        category = optional(string, null)
+        enabled  = optional(bool, true)
+        retention_policy = optional(object({
+          days    = optional(number, 0)
+          enabled = optional(bool, false)
+        }), {})
+      })), [])
+      log_analytics_destination_type           = optional(string, "Dedicated")
+      workspace_resource_id                    = optional(string, null)
+      storage_account_resource_id              = optional(string, null)
+      event_hub_authorization_rule_resource_id = optional(string, null)
+      event_hub_name                           = optional(string, null)
+      marketplace_partner_resource_id          = optional(string, null)
+    })), {})
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    tags = optional(map(string))
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Configuration for a workspace-based Application Insights component or an existing component.
+
+- `deploy` - (Optional) Deploy a new component when `resource_id` is not supplied. Default is false to preserve existing Terraform deployments.
+- `resource_id` - (Optional) Resource ID of an existing Application Insights component. The ID is passed through and no connection string is read or output.
+- `name` - (Optional) Component name.
+- `application_type` - (Optional) Application type. Default is "web".
+- `daily_data_cap_in_gb` - (Optional) Daily data cap. Default is 100.
+- `disable_ip_masking` - (Optional) Disable IP masking. Default is false.
+- `internet_ingestion_enabled` - (Optional) Allow internet ingestion. Default is true while AMPLS composition remains deferred.
+- `internet_query_enabled` - (Optional) Allow internet query. Default is true while AMPLS composition remains deferred.
+- `local_authentication_disabled` - (Optional) Disable local authentication. Default is true.
+- `retention_in_days` - (Optional) Retention period. Default is 90.
+- `allow_mixed_workspaces` - (Optional) Allow reuse of Application Insights without an explicitly reused Log Analytics workspace. Default is false.
+- `enable_diagnostic_settings` - (Optional) Enable component diagnostic settings. Default is false.
+- `diagnostic_settings` - (Optional) Component diagnostic settings.
+- `role_assignments` - (Optional) Component-scoped role assignments.
+- `tags` - (Optional) Component tags.
+DESCRIPTION
+  nullable    = false
+
+  validation {
+    condition     = var.app_insights_definition.resource_id == null || can(provider::azapi::parse_resource_id("Microsoft.Insights/components", var.app_insights_definition.resource_id))
+    error_message = "`app_insights_definition.resource_id` must be a valid Application Insights component resource ID."
+  }
+}
+
 variable "law_definition" {
   type = object({
     deploy      = optional(bool, true)

--- a/variables.monitoring.tf
+++ b/variables.monitoring.tf
@@ -66,7 +66,7 @@ Configuration for a workspace-based Application Insights component or an existin
 - `retention_in_days` - (Optional) Retention period. Default is 90.
 - `allow_mixed_workspaces` - (Optional) Allow reuse of Application Insights without an explicitly reused Log Analytics workspace. Default is false.
 - `enable_diagnostic_settings` - (Optional) Enable component diagnostic settings. Default is false.
-- `diagnostic_settings` - (Optional) Component diagnostic settings.
+- `diagnostic_settings` - (Optional) Component diagnostic settings. When diagnostics are enabled and this map is empty, the automatic setting collects the `allLogs` category group and `AllMetrics`. Supplied settings are preserved without adding categories.
 - `role_assignments` - (Optional) Component-scoped role assignments.
 - `tags` - (Optional) Component tags.
 DESCRIPTION

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,39 @@ If set to true, the module will deploy resources and connect to a platform landi
 DESCRIPTION
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    apimanagement_service_apis                        = optional(list(string), [])
+    apimanagement_service_apis_operations             = optional(list(string), [])
+    apimanagement_service_apis_policies               = optional(list(string), [])
+    apimanagement_service_backends                    = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    bing_accounts                                     = optional(list(string), [])
+    cognitiveservices_accounts                        = optional(list(string), [])
+    insights_components                               = optional(list(string), [])
+    insights_diagnostic_settings                      = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body paths whose changes AzAPI should ignore, keyed by Azure resource type. Paths use dot notation and changes take effect only after apply. Non-empty values require Terraform 1.11 or later.
+
+- `apimanagement_service_apis` - API Management API body paths.
+- `apimanagement_service_apis_operations` - API Management API-operation body paths.
+- `apimanagement_service_apis_policies` - API Management API-policy body paths.
+- `apimanagement_service_backends` - API Management backend body paths.
+- `authorization_role_assignments` - Role-assignment body paths.
+- `bing_accounts` - Grounding with Bing account body paths.
+- `cognitiveservices_accounts` - Cognitive Services account body paths.
+- `insights_components` - Application Insights component body paths.
+- `insights_diagnostic_settings` - Diagnostic-setting body paths.
+- `network_private_endpoints` - Private endpoint body paths.
+- `network_private_endpoints_private_dns_zone_groups` - Private endpoint DNS-zone-group body paths.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "name_prefix" {
   type        = string
   default     = null
@@ -57,6 +90,59 @@ DESCRIPTION
   }
 }
 
+variable "resource_types" {
+  type = object({
+    apimanagement_service_apis                                   = optional(string, "Microsoft.ApiManagement/service/apis@2024-05-01")
+    apimanagement_service_apis_operations                        = optional(string, "Microsoft.ApiManagement/service/apis/operations@2024-05-01")
+    apimanagement_service_apis_policies                          = optional(string, "Microsoft.ApiManagement/service/apis/policies@2024-05-01")
+    apimanagement_service_backends                               = optional(string, "Microsoft.ApiManagement/service/backends@2024-05-01")
+    authorization_role_assignments                               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    bing_accounts                                                = optional(string, "Microsoft.Bing/accounts@2025-05-01-preview")
+    cognitiveservices_accounts                                   = optional(string, "Microsoft.CognitiveServices/accounts@2025-06-01")
+    cognitiveservices_locations_resource_groups_deleted_accounts = optional(string, "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30")
+    insights_components                                          = optional(string, "Microsoft.Insights/components@2020-02-02")
+    insights_components_currentbillingfeatures                   = optional(string, "Microsoft.Insights/components@2015-05-01")
+    insights_diagnostic_settings                                 = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_private_endpoints                                    = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups            = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Azure resource type and API-version overrides for resources managed directly with AzAPI.
+
+- `apimanagement_service_apis` - API Management APIs.
+- `apimanagement_service_apis_operations` - API Management API operations.
+- `apimanagement_service_apis_policies` - API Management API policies.
+- `apimanagement_service_backends` - API Management backends.
+- `authorization_role_assignments` - Azure role assignments.
+- `bing_accounts` - Grounding with Bing accounts.
+- `cognitiveservices_accounts` - Cognitive Services accounts, including Speech.
+- `cognitiveservices_locations_resource_groups_deleted_accounts` - Cognitive Services deleted-account purge endpoint.
+- `insights_components` - Application Insights components.
+- `insights_components_currentbillingfeatures` - Application Insights current billing features singleton.
+- `insights_diagnostic_settings` - Azure Monitor diagnostic settings.
+- `network_private_endpoints` - Private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Private endpoint DNS zone groups.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string), ["ScopeLocked", "Account.*state Accepted"])
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration applied to every AzAPI resource declared directly by this module.
+
+- `error_message_regex` - (Optional) Error-message patterns that trigger retry.
+- `interval_seconds` - (Optional) Initial retry interval in seconds.
+- `max_interval_seconds` - (Optional) Maximum retry interval in seconds.
+DESCRIPTION
+}
+
 variable "tags" {
   type        = map(string)
   default     = null
@@ -64,5 +150,23 @@ variable "tags" {
 Map of tags to be assigned to all resources created by this module.
 
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Default operation timeouts applied to every AzAPI resource declared directly by this module.
+
+- `create` - (Optional) Create timeout as a Go duration string.
+- `delete` - (Optional) Delete timeout as a Go duration string.
+- `read` - (Optional) Read timeout as a Go duration string.
+- `update` - (Optional) Update timeout as a Go duration string.
 DESCRIPTION
 }


### PR DESCRIPTION
## Summary

This draft proposes the authorized, additive Data & AI Services handoff for the Terraform AI landing zone. It is migration-free and does not claim parity, deployment approval, release approval, or publication approval.

- adds the standalone Cosmos SQL `cosmosdb` database and `conversations` container contract
- adds the private Storage `documents` blob-container contract without changing the existing standalone GRS/shared-key or Foundry BYOR ZRS/keyless defaults
- adds opt-in workspace-based Application Insights create/reuse with an existing-workspace consistency guard
- adds opt-in network-isolated Azure AI Speech (`S0`) with system-assigned identity, disabled local auth/public access, private endpoint/DNS integration, diagnostics, and deployment-principal Contributor/User roles
- adds non-secret handoff outputs, an example, generated documentation, and contract tests; deployable providers are mocked, while AzAPI remains real because Terraform cannot mock dependency ephemeral resource types
- raises the AzAPI constraint to the current AVM floor, `~> 2.12`

## Provenance and authorization

- Bicep source: [`Azure/bicep-ptn-aiml-landing-zone@66a0d76f034b8c1003fd63bcdcf58e3255f3d030`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/tree/66a0d76f034b8c1003fd63bcdcf58e3255f3d030)
- Handoff contracts: `parity/handoffs/data-and-ai-services/data-and-ai-services-baseline.json` and `parity/inventory.json`
- Terraform baseline: v0.5.1, commit `abe337894f93de3ddda525ea44898b33e1484070`
- Authorization: [Azure/bicep-ptn-aiml-landing-zone#147 comment 5375280499](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499)
- Semver expectation if accepted: pre-1.0 minor (for example, `0.6.0`); this PR does not release or publish anything

The relevant Terraform capability files were reconciled against current upstream `main`; their baseline blobs are unchanged from v0.5.1.

## Scenario status

| Scenario | Data services | Observability | Search, Bing, Speech |
| --- | --- | --- | --- |
| `standalone-network-isolated` | Implemented statically through existing PE/DNS/peering ordering. | Partial: Log Analytics and Application Insights create/reuse are implemented; AMPLS is deferred. | Existing Search/Bing behavior is preserved; opt-in Speech uses the Cognitive Services private DNS zone and PE subnet. |
| `standalone-standard` | Blocked by the root module's mandatory VNet/private-endpoint architecture. | Blocked by the same architecture. | Blocked by the same architecture. |
| `hub-spoke` | Excluded by the authorized handoff. | Excluded by the authorized handoff. | Excluded by the authorized handoff. |

## Validation evidence

- `avm pre-commit` - pass
- `avm test` - pass (upstream dependency deprecation warnings only)
- `avm test unit` - pass, 6 runs / 6 passed
- `terraform validate` - pass (upstream dependency deprecation warnings only)
- `terraform test -test-directory=tests/unit` - pass, 6 runs / 6 passed
- `git diff --check` - pass
- `avm pr-check` - partial: sync, format, transform, policy, convention, validate, and docs passed; lint failed on 27 pre-existing repository-wide AzureRM/AzAPI compliance findings

No Azure deployment, integration test, DNS resolution test, endpoint reachability test, or release was performed.

## Dependencies and exact deferrals

- AMPLS, its `azuremonitor` private endpoint, scoped-resource links, and Azure Monitor/OMS/ODS/Automation private DNS zones remain one coherent deferred networking dependency. Application Insights therefore retains internet ingestion/query defaults.
- Existing Application Insights connection-string propagation is deferred; this module accepts and outputs only resource IDs and other non-secret values.
- Cosmos SQL data-plane role assignments are deferred pending an AzAPI/AVM design; ARM role assignments are not substituted.
- Default Search, Storage, Key Vault, and workload-identity data-plane RBAC changes are deferred to avoid silent migration/default changes. Speech executor roles are additive because Speech is new and opt-in.
- Bing-to-Foundry connection wiring depends on separately scoped Foundry connection capability groups.
- `standalone-standard` remains blocked by the existing mandatory private-network architecture.
- Full repository migration to the current AzAPI-first resource contract is deferred from this additive handoff. Local `avm pr-check` lint reports 27 existing findings: disallowed direct AzureRM blocks/provider declarations, missing root `resource_types`/`retry`/`timeouts`/`ignore_body_changes`, and missing `response_export_values` on existing AzAPI actions/resources.
- Approved deployment evidence, DNS resolution, endpoint reachability, RBAC behavior, and isolation comparison remain required before any parity claim.

## Review constraints

This is intentionally a **draft** for human review. Do not merge, deploy, release, publish, or claim parity based on this proposal.


