### PR TITLE
fix: retry the AI Foundry purge action on 409 RequestConflict

### DIFF
--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -28,8 +28,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 
   method      = "DELETE"
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${local.ai_foundry_name}"
-  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
+  # The purge races the account's own soft-delete, which returns 409 RequestConflict until it settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 300
+  }
+  type = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30"
+  when = "destroy"
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }


### PR DESCRIPTION
## Summary

`terraform destroy` fails whenever `purge_on_destroy = true`, which is set in all four E2E examples.

`azapi_resource_action.purge_ai_foundry` issues a `DELETE` against the soft-deleted Cognitive Services account immediately after the account itself is destroyed. Azure returns `409 RequestConflict` while that soft-delete is still settling, and the action had no retry configuration, so the first conflict failed the entire destroy:

```
DELETE https://management.azure.com/subscriptions/.../providers/Microsoft.CognitiveServices/
       locations/australiaeast/resourceGroups/ai-lz-rg-default-u81mv/deletedAccounts/ai-foundry-8t6q
RESPONSE 409: 409 Conflict
ERROR CODE: RequestConflict
```

## Impact

Observed on three examples in a single E2E run, every one of them **after a successful apply**:

| Example | apply | destroy |
| --- | --- | --- |
| `default` | exit 0 | failed on purge 409 |
| `default-byo-vnet` | exit 0 | failed on purge 409 |
| `standalone` | exit 0 | failed on purge 409 |

Beyond the red pipeline, a failed purge leaves the account soft-deleted, which then blocks the next run from reusing the same name in that region.

## Fix

Adds a `retry` to the action, scoped to `RequestConflict` with a 30s to 300s backoff, so the purge succeeds once the account deletion settles.

The existing `time_sleep.purge_ai_foundry_cooldown` is left alone. It sequences the purge behind the network teardown, which is a different concern from this conflict, and removing it is out of scope here.

## Testing

- `terraform fmt -recursive -check` — clean
- `terraform validate` — passes, confirming the `retry` shape is accepted by the pinned `azapi ~> 2.4`
- `tflint 0.55.1` on the root scope — zero findings

The real proof is the E2E teardown, which only CI can exercise.

## Notes for reviewers

This is deliberately narrow and independent of #165, so it can merge on its own and unblock teardown for everything else.

Be aware that CI on this branch will still show the `lint` step failing, with roughly 26 `provider_azurerm_disallowed` and TFFR6/7/8 errors. Those are pre-existing and repo-wide, not from this change — see #168 for the detail.
