### PR TITLE
fix!: establish a clean AVM baseline with state-safe AzAPI migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.6.0
+
+### Changed
+
+- Migrated direct control-plane resources from AzureRM to AzAPI 2.12.
+- Added declarative cross-provider state moves for the resource group, network security rules, virtual hub connection, Key Vault deployment-principal role assignment, local example hub resources, and BYO-VNet example resource groups.
+- Added configurable AzAPI resource types, retries, timeouts, response exports, and ignored body paths.
+- Retained `azurerm_client_config` as a documented provider-authentication exception until [Azure/terraform-provider-azapi#981](https://github.com/Azure/terraform-provider-azapi/issues/981) is fixed.
+
+### Upgrade notes
+
+- Back up Terraform state before upgrading from v0.5.1.
+- Run `terraform init -upgrade`, then inspect `terraform plan` for the expected provider/address moves and no resource destruction or replacement.
+- The historical Key Vault role-assignment GUID is retained through provider state migration. New deployments use a deterministic GUID.
+- Read [the v0.6.0 migration guide](./docs/migrations/v0.6.0.md) for the complete procedure and rollback limitation.

--- a/README.md
+++ b/README.md
@@ -15,28 +15,25 @@ Start from one of the deployable examples in this repository:
 
 Copy the example that best matches your environment, then replace `source = "../../"` with the registry source when deploying from your own configuration.
 
-## Policy-restricted environments
+## Provider authentication
 
-If your tenant policies enforce restrictions (for example, storage account key access controls), use the same `azurerm` provider settings as the examples:
+The module uses AzAPI for its direct Azure control-plane operations. It retains one narrowly scoped `azurerm_client_config` data source so the deployment-principal object ID, tenant ID, and subscription ID come from the configured AzureRM provider identity. AzAPI [issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) can otherwise return the Azure CLI identity instead of the configured service principal, managed identity, or provider alias.
+
+Configure both providers with the same authentication context:
 
 ```hcl
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 ```
 
-These settings are used across the examples to help deployments succeed in policy-restricted environments.
+No direct AzureRM resource is created by this module. The client-config exception will be removed after issue #981 is fixed.
+
+## Upgrading from v0.5.1
+
+Version 0.6.0 migrates direct AzureRM control-plane resources to AzAPI. Declarative `moved` blocks preserve the existing resource group, network security rules, virtual hub connection, Key Vault deployment-principal role assignment, and example networking resources.
+
+Read the [v0.6.0 migration guide](./docs/migrations/v0.6.0.md) before upgrading. Back up state and review the upgrade plan before applying because AzAPI provider state migration is one-way.
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements
@@ -45,7 +42,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
@@ -65,11 +62,11 @@ The following resources are used by this module:
 - [azapi_resource.apim_api_policy_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.apim_backend_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.bing_grounding](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.deployment_user_kv_admin](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.network_security_rule](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.virtual_hub_connection](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
-- [azurerm_network_security_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) (resource)
-- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
-- [azurerm_role_assignment.deployment_user_kv_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
-- [azurerm_virtual_hub_connection.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_hub_connection) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_integer.zone_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
@@ -78,8 +75,8 @@ The following resources are used by this module:
 - [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [time_sleep.wait_for_kv_rbac](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
+- [azapi_resource.ai_lz_vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
-- [azurerm_virtual_network.ai_lz_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -2004,6 +2001,38 @@ object({
 
 Default: `{}`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative dot-notation paths to ignore for each AzAPI resource. Ignored configuration is not sent to Azure, and changes to these paths take effect only after apply.
+
+- `apimanagement_service_apis` - Paths ignored on API Management APIs.
+- `apimanagement_service_apis_operations` - Paths ignored on API Management API operations.
+- `apimanagement_service_apis_policies` - Paths ignored on API Management API policies.
+- `apimanagement_service_backends` - Paths ignored on API Management backends.
+- `authorization_role_assignments` - Paths ignored on role assignments.
+- `bing_accounts` - Paths ignored on Bing accounts.
+- `network_network_security_groups_security_rules` - Paths ignored on network security rules.
+- `network_virtual_hubs_hub_virtual_network_connections` - Paths ignored on virtual hub connections.
+- `resources_resource_groups` - Paths ignored on resource groups.
+
+Type:
+
+```hcl
+object({
+    apimanagement_service_apis                           = optional(list(string), [])
+    apimanagement_service_apis_operations                = optional(list(string), [])
+    apimanagement_service_apis_policies                  = optional(list(string), [])
+    apimanagement_service_backends                       = optional(list(string), [])
+    authorization_role_assignments                       = optional(list(string), [])
+    bing_accounts                                        = optional(list(string), [])
+    network_network_security_groups_security_rules       = optional(list(string), [])
+    network_virtual_hubs_hub_virtual_network_connections = optional(list(string), [])
+    resources_resource_groups                            = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_jumpvm_definition"></a> [jumpvm\_definition](#input\_jumpvm\_definition)
 
 Description: Configuration object for the Jump VM to be created for managing the implementation services.
@@ -2258,6 +2287,60 @@ object({
 
 Default: `{}`
 
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `apimanagement_service_apis` - API Management API resource type.
+- `apimanagement_service_apis_operations` - API Management API operation resource type.
+- `apimanagement_service_apis_policies` - API Management API policy resource type.
+- `apimanagement_service_backends` - API Management backend resource type.
+- `authorization_role_assignments` - Role assignment resource type.
+- `bing_accounts` - Bing account resource type.
+- `cognitiveservices_locations_resource_groups_deleted_accounts` - Deleted Cognitive Services account action type.
+- `network_network_security_groups_security_rules` - Network security rule resource type.
+- `network_virtual_hubs_hub_virtual_network_connections` - Virtual hub connection resource type.
+- `resources_resource_groups` - Resource group resource type.
+
+Type:
+
+```hcl
+object({
+    apimanagement_service_apis                                   = optional(string, "Microsoft.ApiManagement/service/apis@2024-05-01")
+    apimanagement_service_apis_operations                        = optional(string, "Microsoft.ApiManagement/service/apis/operations@2024-05-01")
+    apimanagement_service_apis_policies                          = optional(string, "Microsoft.ApiManagement/service/apis/policies@2024-05-01")
+    apimanagement_service_backends                               = optional(string, "Microsoft.ApiManagement/service/backends@2024-05-01")
+    authorization_role_assignments                               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    bing_accounts                                                = optional(string, "Microsoft.Bing/accounts@2025-05-01-preview")
+    cognitiveservices_locations_resource_groups_deleted_accounts = optional(string, "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30")
+    network_network_security_groups_security_rules               = optional(string, "Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01")
+    network_virtual_hubs_hub_virtual_network_connections         = optional(string, "Microsoft.Network/virtualHubs/hubVirtualNetworkConnections@2024-05-01")
+    resources_resource_groups                                    = optional(string, "Microsoft.Resources/resourceGroups@2024-11-01")
+  })
+```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration applied to every supported AzAPI resource declared by this module.
+
+- `error_message_regex` - Regular expressions matching errors that should be retried.
+- `interval_seconds` - Initial interval in seconds between retries.
+- `max_interval_seconds` - Maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `null`
+
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: Map of tags to be assigned to all resources created by this module.
@@ -2265,6 +2348,28 @@ Description: Map of tags to be assigned to all resources created by this module.
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Default per-operation timeouts applied to every supported AzAPI resource declared by this module.
+
+- `create` - Timeout for create operations.
+- `read` - Timeout for read operations.
+- `update` - Timeout for update operations.
+- `delete` - Timeout for delete operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/_header.md
+++ b/_header.md
@@ -13,25 +13,22 @@ Start from one of the deployable examples in this repository:
 
 Copy the example that best matches your environment, then replace `source = "../../"` with the registry source when deploying from your own configuration.
 
-## Policy-restricted environments
+## Provider authentication
 
-If your tenant policies enforce restrictions (for example, storage account key access controls), use the same `azurerm` provider settings as the examples:
+The module uses AzAPI for its direct Azure control-plane operations. It retains one narrowly scoped `azurerm_client_config` data source so the deployment-principal object ID, tenant ID, and subscription ID come from the configured AzureRM provider identity. AzAPI [issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) can otherwise return the Azure CLI identity instead of the configured service principal, managed identity, or provider alias.
+
+Configure both providers with the same authentication context:
 
 ```hcl
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 ```
 
-These settings are used across the examples to help deployments succeed in policy-restricted environments.
+No direct AzureRM resource is created by this module. The client-config exception will be removed after issue #981 is fixed.
+
+## Upgrading from v0.5.1
+
+Version 0.6.0 migrates direct AzureRM control-plane resources to AzAPI. Declarative `moved` blocks preserve the existing resource group, network security rules, virtual hub connection, Key Vault deployment-principal role assignment, and example networking resources.
+
+Read the [v0.6.0 migration guide](./docs/migrations/v0.6.0.md) before upgrading. Back up state and review the upgrade plan before applying because AzAPI provider state migration is one-way.

--- a/docs/adr/0001-azapi-state-migration.md
+++ b/docs/adr/0001-azapi-state-migration.md
@@ -1,0 +1,32 @@
+# ADR 0001: Preserve state while migrating direct resources to AzAPI
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Context
+
+The module directly managed several Azure control-plane resources with AzureRM. Current AVM guidance requires AzAPI for supported direct control-plane operations, but an in-place provider migration must not recreate existing infrastructure.
+
+AzAPI 2.12 implements generic `MoveResourceState` conversion from AzureRM resources to `azapi_resource`. Earlier AzAPI 2.8-2.10 releases had identity migration regressions; the fixes are available in 2.11 and 2.12. AzureRM does not support the reverse conversion.
+
+The existing Key Vault deployment-principal role assignment did not set an explicit name, so AzureRM generated a GUID that varies between deployments. Replacing it with a newly calculated GUID during upgrade would recreate the assignment.
+
+`data.azapi_client_config` also has an unresolved provider-authentication issue that can return the Azure CLI identity instead of the identity configured on a service principal, managed identity, or aliased provider.
+
+## Decision
+
+1. Require AzAPI `~> 2.12`.
+2. Migrate each direct control-plane resource in place and retain its current module/cardinality boundary.
+3. Declare explicit `moved` blocks from each AzureRM address to its AzAPI address.
+4. Retain the moved blocks for at least the next major compatibility window.
+5. Preserve the historical Key Vault role-assignment GUID through provider state conversion and ignore changes to the AzAPI `name` attribute. Use a deterministic UUID only for new deployments.
+6. Keep `data.azurerm_client_config.current` as the only direct AzureRM data source, with block-specific lint exclusions and documentation linking [Azure/terraform-provider-azapi#981](https://github.com/Azure/terraform-provider-azapi/issues/981). Remove the exception when that issue is fixed.
+7. Require consumers to back up state and verify that the upgrade plan contains no unintended destroy or replacement actions.
+
+## Consequences
+
+- Existing Azure resource IDs and state ownership are retained without imperative state commands.
+- Provider migration is declarative and applies to collection instances without enumerating consumer keys.
+- Downgrading after state conversion is unsupported because AzureRM cannot reverse the provider state move.
+- The module retains an AzureRM provider dependency solely for reliable configured-identity discovery until AzAPI issue #981 is resolved.
+- A live upgrade test requires an Azure subscription: deploy v0.5.1, switch to v0.6.0, require a no-destroy/no-replace plan, apply, require a no-change second plan, and destroy through v0.6.0.

--- a/docs/adr/0001-azapi-state-migration.md
+++ b/docs/adr/0001-azapi-state-migration.md
@@ -1,7 +1,7 @@
 # ADR 0001: Preserve state while migrating direct resources to AzAPI
 
 - Status: Accepted
-- Date: 2026-02-23
+- Date: 2026-08-25
 
 ## Context
 

--- a/docs/migrations/v0.6.0.md
+++ b/docs/migrations/v0.6.0.md
@@ -1,0 +1,73 @@
+# Upgrade to v0.6.0
+
+Version 0.6.0 migrates the module's direct Azure control-plane resources from AzureRM to AzAPI 2.12. The resource topology, module inputs, defaults, outputs, names, identity assignments, RBAC, and networking behavior are unchanged.
+
+## Before upgrading
+
+Upgrade directly from v0.5.1 and use Terraform 1.9 or later. Back up the state before changing the module version:
+
+```pwsh
+terraform state pull | Set-Content -Encoding utf8 terraform-state-v0.5.1.backup.json
+terraform state list
+```
+
+Store the backup securely and do not commit it.
+
+## Upgrade procedure
+
+1. Change the module version from `0.5.1` to `0.6.0`.
+2. Initialize the new provider and module versions:
+
+   ```pwsh
+   terraform init -upgrade
+   ```
+
+3. Review the plan:
+
+   ```pwsh
+   terraform plan -out v0.6.0.tfplan
+   ```
+
+4. Confirm the plan reports address/provider moves for the affected resources and does not destroy or replace them.
+5. Apply the reviewed plan:
+
+   ```pwsh
+   terraform apply v0.6.0.tfplan
+   ```
+
+6. Run a second plan and require no changes:
+
+   ```pwsh
+   terraform plan
+   ```
+
+Delete the local plan file after use and do not commit it.
+
+## State moves
+
+The release includes declarative Terraform `moved` blocks for these root-module addresses:
+
+| Previous address | New address |
+| --- | --- |
+| `azurerm_resource_group.this` | `azapi_resource.this` |
+| `azurerm_network_security_rule.this` | `azapi_resource.network_security_rule` |
+| `azurerm_virtual_hub_connection.this` | `azapi_resource.virtual_hub_connection` |
+| `azurerm_role_assignment.deployment_user_kv_admin` | `azapi_resource.deployment_user_kv_admin` |
+
+The local `example_hub_vnet` module also moves its resource group and Bastion host to AzAPI. The `default-byo-vnet` and `standalone-byo-vnet` examples move their supporting VNet resource groups.
+
+AzAPI 2.12 converts the AzureRM provider state while retaining the Azure resource IDs. No manual `terraform state mv`, removal, or import is expected for these addresses.
+
+## Key Vault role-assignment GUID
+
+AzureRM generated the role-assignment GUID when v0.5.1 did not set `name`. The provider state move retains that deployed GUID and the AzAPI resource ignores historical `name` drift, preventing replacement. New deployments use a deterministic UUID derived from the Key Vault ID, principal ID, and role definition ID.
+
+Before applying, verify that the plan does not replace `azapi_resource.deployment_user_kv_admin`. If the assignment is missing from state or was managed outside the module, stop and reconcile/import the existing assignment rather than allowing Terraform to create a duplicate.
+
+## Provider identity
+
+The module intentionally retains `data.azurerm_client_config.current` for the deployment identity. AzAPI [issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) can return the Azure CLI identity instead of the configured service principal, managed identity, or provider alias. Configure AzAPI and AzureRM with the same authentication context. This exception will be removed when issue #981 is fixed.
+
+## Rollback
+
+Cross-provider state migration is one-way: AzureRM does not implement the reverse AzAPI-to-AzureRM state conversion. Do not downgrade the module after applying v0.6.0 state moves. Restore the pre-upgrade state backup only as part of a coordinated rollback before making any subsequent infrastructure changes.

--- a/examples/default-byo-vnet/README.md
+++ b/examples/default-byo-vnet/README.md
@@ -10,12 +10,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -29,24 +30,16 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group
@@ -97,9 +90,13 @@ module "vm_sku" {
 }
 
 # Add a vnet in a separate resource group
-resource "azurerm_resource_group" "vnet_rg" {
-  location = local.location
-  name     = module.naming.resource_group.name_unique
+resource "azapi_resource" "vnet_rg" {
+  type      = "Microsoft.Resources/resourceGroups@2024-11-01"
+  name      = module.naming.resource_group.name_unique
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  location  = local.location
+
+  response_export_values = []
 }
 
 #create a sample hub to mimic an existing network landing zone configuration
@@ -123,8 +120,8 @@ module "vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "=0.16.0"
 
-  location      = azurerm_resource_group.vnet_rg.location
-  parent_id     = azurerm_resource_group.vnet_rg.id
+  location      = azapi_resource.vnet_rg.location
+  parent_id     = azapi_resource.vnet_rg.id
   address_space = ["192.168.0.0/20"]
   dns_servers = {
     dns_servers = [for key, value in module.example_hub.dns_resolver_inbound_ip_addresses : value]
@@ -315,9 +312,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 
@@ -327,8 +324,8 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) (resource)
-- [azurerm_resource_group.vnet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azapi_resource.vnet_rg](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [http_http.ip](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) (data source)

--- a/examples/default-byo-vnet/features.tf
+++ b/examples/default-byo-vnet/features.tf
@@ -4,4 +4,6 @@ resource "azapi_update_resource" "allow_drop_unencrypted_vnet" {
   body = {
     properties = {}
   }
+
+  response_export_values = []
 }

--- a/examples/default-byo-vnet/main.tf
+++ b/examples/default-byo-vnet/main.tf
@@ -3,12 +3,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -22,24 +23,16 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group
@@ -90,9 +83,13 @@ module "vm_sku" {
 }
 
 # Add a vnet in a separate resource group
-resource "azurerm_resource_group" "vnet_rg" {
-  location = local.location
-  name     = module.naming.resource_group.name_unique
+resource "azapi_resource" "vnet_rg" {
+  type      = "Microsoft.Resources/resourceGroups@2024-11-01"
+  name      = module.naming.resource_group.name_unique
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  location  = local.location
+
+  response_export_values = []
 }
 
 #create a sample hub to mimic an existing network landing zone configuration
@@ -116,8 +113,8 @@ module "vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "=0.16.0"
 
-  location      = azurerm_resource_group.vnet_rg.location
-  parent_id     = azurerm_resource_group.vnet_rg.id
+  location      = azapi_resource.vnet_rg.location
+  parent_id     = azapi_resource.vnet_rg.id
   address_space = ["192.168.0.0/20"]
   dns_servers = {
     dns_servers = [for key, value in module.example_hub.dns_resolver_inbound_ip_addresses : value]

--- a/examples/default-byo-vnet/moved.tf
+++ b/examples/default-byo-vnet/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = azurerm_resource_group.vnet_rg
+  to   = azapi_resource.vnet_rg
+}

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -10,12 +10,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.21"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -29,20 +30,12 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group
@@ -276,9 +269,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 
@@ -288,7 +281,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) (resource)
+- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [http_http.ip](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) (data source)

--- a/examples/default/features.tf
+++ b/examples/default/features.tf
@@ -4,4 +4,6 @@ resource "azapi_update_resource" "allow_drop_unencrypted_vnet" {
   body = {
     properties = {}
   }
+
+  response_export_values = []
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -3,12 +3,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.21"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -22,20 +23,12 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group

--- a/examples/standalone-byo-vnet/README.md
+++ b/examples/standalone-byo-vnet/README.md
@@ -10,12 +10,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.21"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -29,24 +30,16 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group
@@ -98,17 +91,21 @@ module "vm_sku" {
 
 # Add a vnet in a separate resource group
 
-resource "azurerm_resource_group" "vnet_rg" {
-  location = local.location
-  name     = module.naming.resource_group.name_unique
+resource "azapi_resource" "vnet_rg" {
+  type      = "Microsoft.Resources/resourceGroups@2024-11-01"
+  name      = module.naming.resource_group.name_unique
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  location  = local.location
+
+  response_export_values = []
 }
 
 module "vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "=0.16.0"
 
-  location      = azurerm_resource_group.vnet_rg.location
-  parent_id     = azurerm_resource_group.vnet_rg.id
+  location      = azapi_resource.vnet_rg.location
+  parent_id     = azapi_resource.vnet_rg.id
   address_space = ["192.168.0.0/20"]
   name          = module.naming.virtual_network.name_unique
 }
@@ -281,9 +278,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 
@@ -293,8 +290,8 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) (resource)
-- [azurerm_resource_group.vnet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azapi_resource.vnet_rg](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [http_http.ip](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) (data source)

--- a/examples/standalone-byo-vnet/features.tf
+++ b/examples/standalone-byo-vnet/features.tf
@@ -4,4 +4,6 @@ resource "azapi_update_resource" "allow_drop_unencrypted_vnet" {
   body = {
     properties = {}
   }
+
+  response_export_values = []
 }

--- a/examples/standalone-byo-vnet/main.tf
+++ b/examples/standalone-byo-vnet/main.tf
@@ -3,12 +3,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.21"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -22,24 +23,16 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 ## Section to provide a random Azure region for the resource group
@@ -91,17 +84,21 @@ module "vm_sku" {
 
 # Add a vnet in a separate resource group
 
-resource "azurerm_resource_group" "vnet_rg" {
-  location = local.location
-  name     = module.naming.resource_group.name_unique
+resource "azapi_resource" "vnet_rg" {
+  type      = "Microsoft.Resources/resourceGroups@2024-11-01"
+  name      = module.naming.resource_group.name_unique
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  location  = local.location
+
+  response_export_values = []
 }
 
 module "vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "=0.16.0"
 
-  location      = azurerm_resource_group.vnet_rg.location
-  parent_id     = azurerm_resource_group.vnet_rg.id
+  location      = azapi_resource.vnet_rg.location
+  parent_id     = azapi_resource.vnet_rg.id
   address_space = ["192.168.0.0/20"]
   name          = module.naming.virtual_network.name_unique
 }

--- a/examples/standalone-byo-vnet/moved.tf
+++ b/examples/standalone-byo-vnet/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = azurerm_resource_group.vnet_rg
+  to   = azapi_resource.vnet_rg
+}

--- a/examples/standalone/README.md
+++ b/examples/standalone/README.md
@@ -10,12 +10,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -29,18 +30,7 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 ## Section to provide a random Azure region for the resource group
@@ -78,6 +68,9 @@ locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 module "vm_sku" {
@@ -261,9 +254,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 
@@ -273,7 +266,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) (resource)
+- [azapi_update_resource.allow_drop_unencrypted_vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [http_http.ip](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) (data source)

--- a/examples/standalone/features.tf
+++ b/examples/standalone/features.tf
@@ -4,4 +4,6 @@ resource "azapi_update_resource" "allow_drop_unencrypted_vnet" {
   body = {
     properties = {}
   }
+
+  response_export_values = []
 }

--- a/examples/standalone/main.tf
+++ b/examples/standalone/main.tf
@@ -3,12 +3,13 @@ terraform {
 
   required_providers {
     azapi = {
-      source  = "azure/azapi"
-      version = "~> 2.0"
+      source  = "Azure/azapi"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = "~> 4.0"
     }
     http = {
       source  = "hashicorp/http"
@@ -22,18 +23,7 @@ terraform {
 }
 
 provider "azurerm" {
-  storage_use_azuread = true
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-    virtual_machine {
-      delete_os_disk_on_deletion = true
-    }
-    cognitive_account {
-      purge_soft_delete_on_destroy = true
-    }
-  }
+  features {}
 }
 
 ## Section to provide a random Azure region for the resource group
@@ -71,6 +61,9 @@ locals {
   location = "australiaeast"
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 module "vm_sku" {

--- a/locals.genai_services.tf
+++ b/locals.genai_services.tf
@@ -69,7 +69,7 @@ locals {
         failover_priority = 1
       },
       {
-        location          = azurerm_resource_group.this.location
+        location          = azapi_resource.this.location
         zone_redundant    = false #length(local.region_zones) > 1 ? true : false
         failover_priority = 0
       }

--- a/locals.networking.tf
+++ b/locals.networking.tf
@@ -365,7 +365,7 @@ locals {
   }
   subnets_definition       = var.vnet_definition.subnets
   virtual_network_links    = merge(local.default_virtual_network_link, var.private_dns_zones.network_links)
-  vnet_address_space       = length(var.vnet_definition.existing_byo_vnet) > 0 ? data.azurerm_virtual_network.ai_lz_vnet[0].address_space[0] : var.vnet_definition.address_space[0]
+  vnet_address_space       = length(var.vnet_definition.existing_byo_vnet) > 0 ? data.azapi_resource.ai_lz_vnet[0].output.properties.addressSpace.addressPrefixes[0] : var.vnet_definition.address_space[0]
   vnet_diagnostic_settings = var.vnet_definition.enable_diagnostic_settings ? (length(var.vnet_definition.diagnostic_settings) > 0 ? var.vnet_definition.diagnostic_settings : local.vnet_diagnostic_settings_inner) : {}
   vnet_diagnostic_settings_inner = (local.deploy_diagnostics_settings ? {
     sendToLogAnalytics = {
@@ -382,7 +382,7 @@ locals {
     }
   } : {})
   vnet_name        = length(var.vnet_definition.existing_byo_vnet) > 0 ? try(basename(values(var.vnet_definition.existing_byo_vnet)[0].vnet_resource_id), null) : (try(var.vnet_definition.name, null) != null ? var.vnet_definition.name : (var.name_prefix != null ? "${var.name_prefix}-vnet" : "ai-alz-vnet"))
-  vnet_resource_id = length(var.vnet_definition.existing_byo_vnet) > 0 ? data.azurerm_virtual_network.ai_lz_vnet[0].id : module.ai_lz_vnet[0].resource_id
+  vnet_resource_id = length(var.vnet_definition.existing_byo_vnet) > 0 ? data.azapi_resource.ai_lz_vnet[0].id : module.ai_lz_vnet[0].resource_id
   #web_application_firewall_managed_rules = var.waf_policy_definition.managed_rules == null ? {
   #  managed_rule_set = tomap({
   #    owasp = {

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,8 @@
 locals {
-  paired_region = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azurerm_resource_group.this.location) || (lower(region.display_name) == lower(azurerm_resource_group.this.location)))][0].paired_region_name
+  paired_region = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azapi_resource.this.location) || (lower(region.display_name) == lower(azapi_resource.this.location)))][0].paired_region_name
   #paired_region_zones        = local.paired_region_zones_lookup != null ? local.paired_region_zones_lookup : []
   #paired_region_zones_lookup = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(local.paired_region) || (lower(region.display_name) == lower(local.paired_region)))][0].zones
   region_zones        = local.region_zones_lookup != null ? local.region_zones_lookup : []
-  region_zones_lookup = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azurerm_resource_group.this.location) || (lower(region.display_name) == lower(azurerm_resource_group.this.location)))][0].zones
+  region_zones_lookup = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azapi_resource.this.location) || (lower(region.display_name) == lower(azapi_resource.this.location)))][0].zones
   tags                = var.tags != null ? var.tags : {}
 }

--- a/main.apim.tf
+++ b/main.apim.tf
@@ -3,10 +3,10 @@ module "apim" {
   version = "0.0.5"
   count   = var.apim_definition.deploy ? 1 : 0
 
-  location                   = azurerm_resource_group.this.location
+  location                   = azapi_resource.this.location
   name                       = local.apim_name
   publisher_email            = var.apim_definition.publisher_email
-  resource_group_name        = azurerm_resource_group.this.name
+  resource_group_name        = azapi_resource.this.name
   additional_location        = var.apim_definition.additional_locations
   certificate                = var.apim_definition.certificate
   client_certificate_enabled = var.apim_definition.client_certificate_enabled
@@ -36,6 +36,6 @@ module "apim" {
   zones                         = var.apim_definition.sku_root == "Premium" ? local.region_zones : null
 
   depends_on = [
-    azurerm_network_security_rule.this
+    azapi_resource.network_security_rule
   ]
 }

--- a/main.apim_apis.tf
+++ b/main.apim_apis.tf
@@ -14,7 +14,7 @@ resource "azapi_resource" "apim_backend_ai_foundry" {
 
   name      = "ai-foundry-backend"
   parent_id = module.apim[0].resource_id
-  type      = "Microsoft.ApiManagement/service/backends@2024-05-01"
+  type      = var.resource_types.apimanagement_service_backends
   body = {
     properties = {
       description = "Azure AI Foundry backend service"
@@ -28,9 +28,21 @@ resource "azapi_resource" "apim_backend_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_backends) > 0 ? var.ignore_body_changes.apimanagement_service_backends : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 
   depends_on = [time_sleep.apim_ready]
 }
@@ -40,7 +52,7 @@ resource "azapi_resource" "apim_api_ai_foundry" {
 
   name      = "azure-openai-api"
   parent_id = module.apim[0].resource_id
-  type      = "Microsoft.ApiManagement/service/apis@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis
   body = {
     properties = {
       description = "Sample API for Azure AI Foundry - validates APIM to AI Foundry connectivity"
@@ -60,9 +72,21 @@ resource "azapi_resource" "apim_api_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis) > 0 ? var.ignore_body_changes.apimanagement_service_apis : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 
   depends_on = [azapi_resource.apim_backend_ai_foundry]
 }
@@ -72,7 +96,7 @@ resource "azapi_resource" "apim_api_operation_chat_completions" {
 
   name      = "chat-completions"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/operations@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_operations
   body = {
     properties = {
       description = "Creates a completion for the chat message using a deployed model."
@@ -102,9 +126,21 @@ resource "azapi_resource" "apim_api_operation_chat_completions" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_operations) > 0 ? var.ignore_body_changes.apimanagement_service_apis_operations : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 }
 
 resource "azapi_resource" "apim_api_operation_list_models" {
@@ -112,7 +148,7 @@ resource "azapi_resource" "apim_api_operation_list_models" {
 
   name      = "list-models"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/operations@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_operations
   body = {
     properties = {
       description = "Lists the available models for the Azure OpenAI service."
@@ -134,9 +170,21 @@ resource "azapi_resource" "apim_api_operation_list_models" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_operations) > 0 ? var.ignore_body_changes.apimanagement_service_apis_operations : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 }
 
 resource "azapi_resource" "apim_api_policy_ai_foundry" {
@@ -144,7 +192,7 @@ resource "azapi_resource" "apim_api_policy_ai_foundry" {
 
   name      = "policy"
   parent_id = azapi_resource.apim_api_ai_foundry[0].id
-  type      = "Microsoft.ApiManagement/service/apis/policies@2024-05-01"
+  type      = var.resource_types.apimanagement_service_apis_policies
   body = {
     properties = {
       format = "rawxml"
@@ -169,9 +217,21 @@ resource "azapi_resource" "apim_api_policy_ai_foundry" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.apimanagement_service_apis_policies) > 0 ? var.ignore_body_changes.apimanagement_service_apis_policies : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 
   lifecycle {
     ignore_changes = [body]

--- a/main.build.tf
+++ b/main.build.tf
@@ -3,7 +3,7 @@ module "buildvm" {
   version = "0.20.0"
   count   = !var.flag_platform_landing_zone && var.buildvm_definition.deploy ? 1 : 0
 
-  location = azurerm_resource_group.this.location
+  location = azapi_resource.this.location
   name     = local.build_vm_name
   network_interfaces = {
     network_interface_1 = {
@@ -16,7 +16,7 @@ module "buildvm" {
       }
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   zone                = length(local.region_zones) > 0 ? random_integer.zone_index[0].result : null
   account_credentials = {
     key_vault_configuration = {
@@ -34,7 +34,7 @@ module "buildvm" {
   os_type = "Linux"
   role_assignments_system_managed_identity = {
     rg_owner = {
-      scope_resource_id          = azurerm_resource_group.this.id
+      scope_resource_id          = azapi_resource.this.id
       role_definition_id_or_name = "Owner"
       description                = "Assign the owner role to the build machine's system assigned identity on the resource group."
     }

--- a/main.compute.tf
+++ b/main.compute.tf
@@ -3,12 +3,12 @@ module "container_apps_managed_environment" {
   version = "0.3.0"
   count   = var.container_app_environment_definition.deploy ? 1 : 0
 
-  location                           = azurerm_resource_group.this.location
+  location                           = azapi_resource.this.location
   name                               = local.container_app_environment_name
-  resource_group_name                = azurerm_resource_group.this.name
+  resource_group_name                = azapi_resource.this.name
   diagnostic_settings                = local.cae_diagnostic_settings
   enable_telemetry                   = var.enable_telemetry
-  infrastructure_resource_group_name = "rg-managed-${azurerm_resource_group.this.name}"
+  infrastructure_resource_group_name = "rg-managed-${azapi_resource.this.name}"
   infrastructure_subnet_id           = local.subnet_ids["ContainerAppEnvironmentSubnet"]
   internal_load_balancer_enabled     = var.container_app_environment_definition.internal_load_balancer_enabled
   log_analytics_workspace = {

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -4,8 +4,8 @@ module "foundry_ptn" {
 
   #configure the base resource
   base_name                  = coalesce(var.name_prefix, "foundry")
-  location                   = azurerm_resource_group.this.location
-  resource_group_resource_id = azurerm_resource_group.this.id
+  location                   = azapi_resource.this.location
+  resource_group_resource_id = azapi_resource.this.id
   #pass through the resource definitions
   ai_foundry                          = local.foundry_ai_foundry
   ai_model_deployments                = var.ai_foundry_definition.ai_model_deployments
@@ -26,10 +26,22 @@ module "foundry_ptn" {
 resource "azapi_resource_action" "purge_ai_foundry" {
   count = var.ai_foundry_definition.purge_on_destroy ? 1 : 0
 
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${local.ai_foundry_name}"
-  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
+  method                 = "DELETE"
+  resource_id            = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azapi_resource.this.location}/resourceGroups/${azapi_resource.this.name}/deletedAccounts/${local.ai_foundry_name}"
+  type                   = var.resource_types.cognitiveservices_locations_resource_groups_deleted_accounts
+  response_export_values = []
+  retry                  = var.retry
+  when                   = "destroy"
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/main.genai_services.tf
+++ b/main.genai_services.tf
@@ -3,9 +3,9 @@ module "avm_res_keyvault_vault" {
   version = "=0.10.2"
   count   = var.genai_key_vault_definition.deploy ? 1 : 0
 
-  location                        = azurerm_resource_group.this.location
+  location                        = azapi_resource.this.location
   name                            = local.genai_key_vault_name
-  resource_group_name             = azurerm_resource_group.this.name
+  resource_group_name             = azapi_resource.this.name
   tenant_id                       = var.genai_key_vault_definition.tenant_id != null ? var.genai_key_vault_definition.tenant_id : data.azurerm_client_config.current.tenant_id
   diagnostic_settings             = local.genai_key_vault_diagnostic_settings
   enabled_for_deployment          = true
@@ -36,12 +36,39 @@ module "avm_res_keyvault_vault" {
 
 #moving this outside of the KV AVM module so I can set an implicit dependency from the jump vm module to order deletion properly.
 #TODO: Review if this permission is too permissive.  Can this be Secrets User instead?
-resource "azurerm_role_assignment" "deployment_user_kv_admin" {
+resource "azapi_resource" "deployment_user_kv_admin" {
   count = var.genai_key_vault_definition.deploy ? 1 : 0
 
-  principal_id         = data.azurerm_client_config.current.object_id
-  scope                = module.avm_res_keyvault_vault[0].resource_id
-  role_definition_name = "Key Vault Administrator"
+  name      = uuidv5("url", "${module.avm_res_keyvault_vault[0].resource_id}|${data.azurerm_client_config.current.object_id}|00482a5a-887f-4fb3-b363-3b7fe8e74483")
+  parent_id = module.avm_res_keyvault_vault[0].resource_id
+  type      = var.resource_types.authorization_role_assignments
+  body = {
+    properties = {
+      principalId      = data.azurerm_client_config.current.object_id
+      roleDefinitionId = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483"
+    }
+  }
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
+  response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 resource "time_sleep" "wait_for_kv_rbac" {
@@ -49,10 +76,10 @@ resource "time_sleep" "wait_for_kv_rbac" {
 
   create_duration = "60s"
   triggers = {
-    role_assignment = azurerm_role_assignment.deployment_user_kv_admin[0].id
+    role_assignment = azapi_resource.deployment_user_kv_admin[0].id
   }
 
-  depends_on = [azurerm_role_assignment.deployment_user_kv_admin]
+  depends_on = [azapi_resource.deployment_user_kv_admin]
 }
 
 #TODO:
@@ -63,9 +90,9 @@ module "cosmosdb" {
   version = "0.10.0"
   count   = var.genai_cosmosdb_definition.deploy ? 1 : 0
 
-  location                   = azurerm_resource_group.this.location
+  location                   = azapi_resource.this.location
   name                       = local.genai_cosmosdb_name
-  resource_group_name        = azurerm_resource_group.this.name
+  resource_group_name        = azapi_resource.this.name
   analytical_storage_config  = var.genai_cosmosdb_definition.analytical_storage_config
   analytical_storage_enabled = var.genai_cosmosdb_definition.analytical_storage_enabled
   automatic_failover_enabled = var.genai_cosmosdb_definition.automatic_failover_enabled
@@ -113,9 +140,9 @@ module "storage_account" {
   version = "0.6.6"
   count   = var.genai_storage_account_definition.deploy ? 1 : 0
 
-  location                            = azurerm_resource_group.this.location
+  location                            = azapi_resource.this.location
   name                                = local.genai_storage_account_name
-  resource_group_name                 = azurerm_resource_group.this.name
+  resource_group_name                 = azapi_resource.this.name
   access_tier                         = var.genai_storage_account_definition.access_tier
   account_kind                        = var.genai_storage_account_definition.account_kind
   account_replication_type            = var.genai_storage_account_definition.account_replication_type
@@ -145,9 +172,9 @@ module "containerregistry" {
   version = "0.5.0"
   count   = var.genai_container_registry_definition.deploy ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.genai_container_registry_name
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   diagnostic_settings = local.genai_container_registry_diagnostic_settings
   enable_telemetry    = var.enable_telemetry
   private_endpoints = {
@@ -169,9 +196,9 @@ module "app_configuration" {
   version = "0.5.1"
   count   = var.genai_app_configuration_definition.deploy ? 1 : 0
 
-  location                        = azurerm_resource_group.this.location
+  location                        = azapi_resource.this.location
   name                            = local.genai_app_configuration_name
-  resource_group_resource_id      = azurerm_resource_group.this.id
+  resource_group_resource_id      = azapi_resource.this.id
   azapi_schema_validation_enabled = false
   diagnostic_settings             = local.genai_app_configuration_diagnostic_settings
   enable_telemetry                = var.enable_telemetry

--- a/main.genai_services.tf
+++ b/main.genai_services.tf
@@ -48,9 +48,13 @@ resource "azapi_resource" "deployment_user_kv_admin" {
       roleDefinitionId = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483"
     }
   }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
@@ -65,10 +69,6 @@ resource "azapi_resource" "deployment_user_kv_admin" {
   lifecycle {
     ignore_changes = [name]
   }
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 resource "time_sleep" "wait_for_kv_rbac" {

--- a/main.genai_services.tf
+++ b/main.genai_services.tf
@@ -48,10 +48,14 @@ resource "azapi_resource" "deployment_user_kv_admin" {
       roleDefinitionId = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483"
     }
   }
-  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
-  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs = [
+    "properties.principalId",
+    "properties.roleDefinitionId",
+  ]
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.jumpvm.tf
+++ b/main.jumpvm.tf
@@ -10,7 +10,7 @@ module "jumpvm" {
   version = "0.20.0"
   count   = !var.flag_platform_landing_zone && var.jumpvm_definition.deploy ? 1 : 0
 
-  location = azurerm_resource_group.this.location
+  location = azapi_resource.this.location
   name     = local.jump_vm_name
   network_interfaces = {
     network_interface_1 = {
@@ -23,7 +23,7 @@ module "jumpvm" {
       }
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   zone                = length(local.region_zones) > 0 ? random_integer.zone_index[0].result : null
   account_credentials = {
     key_vault_configuration = {

--- a/main.knowledge_sources.tf
+++ b/main.knowledge_sources.tf
@@ -3,9 +3,9 @@ module "search_service" {
   version = "0.2.0"
   count   = var.ks_ai_search_definition.deploy ? 1 : 0
 
-  location                     = azurerm_resource_group.this.location
+  location                     = azapi_resource.this.location
   name                         = local.ks_ai_search_name
-  resource_group_name          = azurerm_resource_group.this.name
+  resource_group_name          = azapi_resource.this.name
   diagnostic_settings          = local.ks_ai_search_diagnostic_settings
   enable_telemetry             = var.enable_telemetry # see variables.tf
   local_authentication_enabled = var.ks_ai_search_definition.local_authentication_enabled
@@ -32,8 +32,8 @@ resource "azapi_resource" "bing_grounding" {
 
   location  = "global"
   name      = local.ks_bing_grounding_name
-  parent_id = azurerm_resource_group.this.id
-  type      = "Microsoft.Bing/accounts@2025-05-01-preview"
+  parent_id = azapi_resource.this.id
+  type      = var.resource_types.bing_accounts
   body = {
     kind = "Bing.Grounding"
     sku = {
@@ -42,10 +42,23 @@ resource "azapi_resource" "bing_grounding" {
   }
   create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes       = length(var.ignore_body_changes.bing_accounts) > 0 ? var.ignore_body_changes.bing_accounts : null
   read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values    = []
+  retry                     = var.retry
   schema_validation_enabled = false
   tags                      = merge(local.tags, var.ks_bing_grounding_definition.tags != null ? var.ks_bing_grounding_definition.tags : {})
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 
   # The Microsoft.Bing/accounts resource provider normalizes tag keys by
   # lower-casing the first character (e.g. "SecurityControl" -> "securityControl"),

--- a/main.monitoring.tf
+++ b/main.monitoring.tf
@@ -3,9 +3,9 @@ module "log_analytics_workspace" {
   version = "0.4.2"
   count   = var.law_definition.resource_id == null && var.law_definition.deploy ? 1 : 0
 
-  location                                  = azurerm_resource_group.this.location
+  location                                  = azapi_resource.this.location
   name                                      = local.log_analytics_workspace_name
-  resource_group_name                       = azurerm_resource_group.this.name
+  resource_group_name                       = azapi_resource.this.name
   enable_telemetry                          = var.enable_telemetry
   log_analytics_workspace_retention_in_days = var.law_definition.retention
   log_analytics_workspace_sku               = var.law_definition.sku

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -137,10 +137,13 @@ resource "azapi_resource" "virtual_hub_connection" {
       }
     }
   }
-  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  ignore_body_changes    = length(var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections) > 0 ? var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections : null
-  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections) > 0 ? var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs = [
+    "properties.remoteVirtualNetwork.id",
+  ]
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -3,8 +3,8 @@ module "ai_lz_vnet" {
   version = "0.16.0"
   count   = length(var.vnet_definition.existing_byo_vnet) > 0 ? 0 : 1
 
-  location      = azurerm_resource_group.this.location
-  parent_id     = azurerm_resource_group.this.id
+  location      = azapi_resource.this.location
+  parent_id     = azapi_resource.this.id
   address_space = var.vnet_definition.ipam_pools == null ? var.vnet_definition.address_space : null
   ddos_protection_plan = var.vnet_definition.ddos_protection_plan_resource_id != null ? {
     id     = var.vnet_definition.ddos_protection_plan_resource_id
@@ -22,11 +22,12 @@ module "ai_lz_vnet" {
   tags             = merge(local.tags, var.vnet_definition.tags != null ? var.vnet_definition.tags : {})
 }
 
-data "azurerm_virtual_network" "ai_lz_vnet" {
+data "azapi_resource" "ai_lz_vnet" {
   count = length(var.vnet_definition.existing_byo_vnet) > 0 ? 1 : 0
 
-  name                = try(basename(values(var.vnet_definition.existing_byo_vnet)[0].vnet_resource_id), "")
-  resource_group_name = split("/", try(values(var.vnet_definition.existing_byo_vnet)[0].vnet_resource_id, "/n/o/t/u/s/e/d"))[4]
+  resource_id            = values(var.vnet_definition.existing_byo_vnet)[0].vnet_resource_id
+  type                   = "Microsoft.Network/virtualNetworks@2024-05-01"
+  response_export_values = ["properties.addressSpace"]
 }
 
 module "byo_subnets" {
@@ -48,37 +49,44 @@ module "nsgs" {
   source  = "Azure/avm-res-network-networksecuritygroup/azurerm"
   version = "0.5.0"
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.nsg_name
-  resource_group_name = var.nsgs_definition.resource_group_name != null ? var.nsgs_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name = var.nsgs_definition.resource_group_name != null ? var.nsgs_definition.resource_group_name : azapi_resource.this.name
 }
 
 # NSGs are required during subnet creation but rules use cidrs which are not known until after vnet creation.
 # Therefore, NSG rules are created in a separate resource after the VNet and subnets are created.
-resource "azurerm_network_security_rule" "this" {
+resource "azapi_resource" "network_security_rule" {
   for_each = local.nsg_rules
 
-  access                                     = each.value.access
-  direction                                  = each.value.direction
-  name                                       = each.value.name
-  network_security_group_name                = module.nsgs.resource.name
-  priority                                   = each.value.priority
-  protocol                                   = each.value.protocol
-  resource_group_name                        = module.nsgs.resource.resource_group_name
-  description                                = try(each.value.description, null)
-  destination_address_prefix                 = try(each.value.destination_address_prefix, null)
-  destination_address_prefixes               = try(each.value.destination_address_prefixes, null)
-  destination_application_security_group_ids = try(each.value.destination_application_security_group_ids, null)
-  destination_port_range                     = try(each.value.destination_port_range, null)
-  destination_port_ranges                    = try(each.value.destination_port_ranges, null)
-  source_address_prefix                      = try(each.value.source_address_prefix, null)
-  source_address_prefixes                    = try(each.value.source_address_prefixes, null)
-  source_application_security_group_ids      = try(each.value.source_application_security_group_ids, null)
-  source_port_range                          = try(each.value.source_port_range, null)
-  source_port_ranges                         = try(each.value.source_port_ranges, null)
+  name      = each.value.name
+  parent_id = module.nsgs.resource_id
+  type      = var.resource_types.network_network_security_groups_security_rules
+  body = {
+    properties = {
+      access                               = each.value.access
+      direction                            = each.value.direction
+      priority                             = each.value.priority
+      protocol                             = each.value.protocol
+      description                          = try(each.value.description, null)
+      destinationAddressPrefix             = try(each.value.destination_address_prefix, null)
+      destinationAddressPrefixes           = try(tolist(each.value.destination_address_prefixes), null)
+      destinationApplicationSecurityGroups = try([for id in each.value.destination_application_security_group_ids : { id = id }], null)
+      destinationPortRange                 = try(each.value.destination_port_range, null)
+      destinationPortRanges                = try(tolist(each.value.destination_port_ranges), null)
+      sourceAddressPrefix                  = try(each.value.source_address_prefix, null)
+      sourceAddressPrefixes                = try(tolist(each.value.source_address_prefixes), null)
+      sourceApplicationSecurityGroups      = try([for id in each.value.source_application_security_group_ids : { id = id }], null)
+      sourcePortRange                      = try(each.value.source_port_range, null)
+      sourcePortRanges                     = try(tolist(each.value.source_port_ranges), null)
+    }
+  }
+  ignore_body_changes    = length(var.ignore_body_changes.network_network_security_groups_security_rules) > 0 ? var.ignore_body_changes.network_network_security_groups_security_rules : null
+  response_export_values = []
+  retry                  = var.retry
 
   dynamic "timeouts" {
-    for_each = try(each.value.timeouts, null) == null ? [] : [each.value.timeouts]
+    for_each = coalesce(try(each.value.timeouts, null), var.timeouts) == null ? [] : [coalesce(try(each.value.timeouts, null), var.timeouts)]
 
     content {
       create = timeouts.value.create
@@ -87,6 +95,10 @@ resource "azurerm_network_security_rule" "this" {
       update = timeouts.value.update
     }
   }
+  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 #TODO: Add the platform landing zone flag as a secondary decision point for the hub vnet peering?
@@ -112,12 +124,36 @@ module "hub_vnet_peering" {
 
 #TODO: Add the platform landing zone flag as a secondary decision point for the vwan connection?
 #peer_vwan_hub_resource_id
-resource "azurerm_virtual_hub_connection" "this" {
+resource "azapi_resource" "virtual_hub_connection" {
   count = length(var.vnet_definition.existing_byo_vnet) == 0 && try(var.vnet_definition.vwan_hub_peering_configuration.peer_vwan_hub_resource_id, null) != null ? 1 : 0
 
-  name                      = "${local.vnet_name}-to-${basename(var.vnet_definition.vwan_hub_peering_configuration.peer_vwan_hub_resource_id)}"
-  remote_virtual_network_id = local.vnet_resource_id
-  virtual_hub_id            = var.vnet_definition.vwan_hub_peering_configuration.peer_vwan_hub_resource_id
+  name      = "${local.vnet_name}-to-${basename(var.vnet_definition.vwan_hub_peering_configuration.peer_vwan_hub_resource_id)}"
+  parent_id = var.vnet_definition.vwan_hub_peering_configuration.peer_vwan_hub_resource_id
+  type      = var.resource_types.network_virtual_hubs_hub_virtual_network_connections
+  body = {
+    properties = {
+      remoteVirtualNetwork = {
+        id = local.vnet_resource_id
+      }
+    }
+  }
+  ignore_body_changes    = length(var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections) > 0 ? var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections : null
+  response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 module "firewall_route_table" {
@@ -126,9 +162,9 @@ module "firewall_route_table" {
   count = ((!var.flag_platform_landing_zone && length(var.vnet_definition.existing_byo_vnet) == 0) ||
   (!var.flag_platform_landing_zone && length(var.vnet_definition.existing_byo_vnet) > 0 && try(values(var.vnet_definition.existing_byo_vnet)[0].firewall_ip_address, null) != null)) ? 1 : 0
 
-  location                      = azurerm_resource_group.this.location
+  location                      = azapi_resource.this.location
   name                          = local.route_table_name
-  resource_group_name           = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name           = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azapi_resource.this.name
   bgp_route_propagation_enabled = true
   routes = var.use_internet_routing ? {
     internet_route = {
@@ -151,9 +187,9 @@ module "fw_pip" {
   version = "0.2.0"
   count   = !var.flag_platform_landing_zone && length(var.vnet_definition.existing_byo_vnet) == 0 ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = "${local.firewall_name}-pip"
-  resource_group_name = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
   zones               = var.firewall_definition.zones
 }
@@ -165,9 +201,9 @@ module "firewall" {
 
   firewall_sku_name   = var.firewall_definition.sku
   firewall_sku_tier   = var.firewall_definition.tier
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.firewall_name
-  resource_group_name = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name = var.firewall_definition.resource_group_name != null ? var.firewall_definition.resource_group_name : azapi_resource.this.name
   diagnostic_settings = local.az_fw_diagnostic_settings
   enable_telemetry    = var.enable_telemetry
   firewall_ip_configuration = [
@@ -188,9 +224,9 @@ module "firewall_policy" {
   version = "0.3.3"
   count   = !var.flag_platform_landing_zone && var.firewall_definition.deploy && length(var.vnet_definition.existing_byo_vnet) == 0 ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = "${local.firewall_name}-policy"
-  resource_group_name = var.firewall_policy_definition.resource_group_name != null ? var.firewall_policy_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name = var.firewall_policy_definition.resource_group_name != null ? var.firewall_policy_definition.resource_group_name : azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
 }
 
@@ -211,9 +247,9 @@ module "azure_bastion" {
   version = "0.7.2"
   count   = !var.flag_platform_landing_zone && var.bastion_definition.deploy ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.bastion_name
-  resource_group_name = var.bastion_definition.resource_group_name != null ? var.bastion_definition.resource_group_name : azurerm_resource_group.this.name
+  resource_group_name = var.bastion_definition.resource_group_name != null ? var.bastion_definition.resource_group_name : azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
   ip_configuration = {
     subnet_id = local.subnet_ids["AzureBastionSubnet"]
@@ -229,7 +265,7 @@ module "private_dns_zones" {
   for_each = !var.flag_platform_landing_zone ? local.private_dns_zones : {}
 
   domain_name           = each.value.name
-  parent_id             = azurerm_resource_group.this.id
+  parent_id             = azapi_resource.this.id
   enable_telemetry      = var.enable_telemetry
   virtual_network_links = local.virtual_network_links
 
@@ -261,10 +297,10 @@ module "app_gateway_waf_policy" {
   version = "0.2.0"
   count   = var.app_gateway_definition.deploy ? 1 : 0
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   managed_rules       = var.waf_policy_definition.managed_rules #local.web_application_firewall_managed_rules
   name                = local.web_application_firewall_policy_name
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
   policy_settings     = var.waf_policy_definition.policy_settings
   tags                = merge(local.tags, var.waf_policy_definition.tags != null ? var.waf_policy_definition.tags : {})
@@ -282,10 +318,10 @@ module "application_gateway" {
     subnet_id = local.subnet_ids["AppGatewaySubnet"]
   }
   http_listeners                     = var.app_gateway_definition.http_listeners
-  location                           = azurerm_resource_group.this.location
+  location                           = azapi_resource.this.location
   name                               = local.application_gateway_name
   request_routing_rules              = var.app_gateway_definition.request_routing_rules
-  resource_group_name                = azurerm_resource_group.this.name
+  resource_group_name                = azapi_resource.this.name
   app_gateway_waf_policy_resource_id = one(module.app_gateway_waf_policy[*].resource_id)
   authentication_certificate         = var.app_gateway_definition.authentication_certificate
   autoscale_configuration            = var.app_gateway_definition.autoscale_configuration
@@ -308,6 +344,6 @@ module "application_gateway" {
   zones                              = local.region_zones
 
   depends_on = [
-    azurerm_network_security_rule.this
+    azapi_resource.network_security_rule
   ]
 }

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -81,12 +81,16 @@ resource "azapi_resource" "network_security_rule" {
       sourcePortRanges                     = try(tolist(each.value.source_port_ranges), null)
     }
   }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.network_network_security_groups_security_rules) > 0 ? var.ignore_body_changes.network_network_security_groups_security_rules : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "timeouts" {
-    for_each = coalesce(try(each.value.timeouts, null), var.timeouts) == null ? [] : [coalesce(try(each.value.timeouts, null), var.timeouts)]
+    for_each = try(each.value.timeouts, null) != null ? [each.value.timeouts] : var.timeouts == null ? [] : [var.timeouts]
 
     content {
       create = timeouts.value.create
@@ -95,10 +99,6 @@ resource "azapi_resource" "network_security_rule" {
       update = timeouts.value.update
     }
   }
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 #TODO: Add the platform landing zone flag as a secondary decision point for the hub vnet peering?
@@ -137,9 +137,13 @@ resource "azapi_resource" "virtual_hub_connection" {
       }
     }
   }
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections) > 0 ? var.ignore_body_changes.network_virtual_hubs_hub_virtual_network_connections : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
@@ -150,10 +154,6 @@ resource "azapi_resource" "virtual_hub_connection" {
       delete = timeouts.value.delete
     }
   }
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 module "firewall_route_table" {

--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,14 @@ resource "azapi_resource" "this" {
   name                   = var.resource_group_name
   parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
   type                   = var.resource_types.resources_resource_groups
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.resources_resource_groups) > 0 ? var.ignore_body_changes.resources_resource_groups : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   tags                   = var.tags
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
@@ -17,10 +21,6 @@ resource "azapi_resource" "this" {
       delete = timeouts.value.delete
     }
   }
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 # used to randomize resource names that are globally unique

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,26 @@
-resource "azurerm_resource_group" "this" {
-  location = var.location
-  name     = var.resource_group_name
-  tags     = var.tags
+resource "azapi_resource" "this" {
+  location               = var.location
+  name                   = var.resource_group_name
+  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  type                   = var.resource_types.resources_resource_groups
+  ignore_body_changes    = length(var.ignore_body_changes.resources_resource_groups) > 0 ? var.ignore_body_changes.resources_resource_groups : null
+  response_export_values = []
+  retry                  = var.retry
+  tags                   = var.tags
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
 # used to randomize resource names that are globally unique
@@ -11,6 +30,9 @@ resource "random_string" "name_suffix" {
   upper   = false
 }
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 module "avm_utl_regions" {

--- a/modules/example_hub_vnet/README.md
+++ b/modules/example_hub_vnet/README.md
@@ -11,7 +11,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
@@ -21,8 +23,8 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azurerm_bastion_host.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/bastion_host) (resource)
-- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azapi_resource.bastion](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.this](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [random_integer.zone_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
 - [time_sleep.wait_for_kv_rbac](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
@@ -85,6 +87,24 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative dot-notation paths to ignore for each AzAPI resource. Ignored configuration is not sent to Azure, and changes to these paths take effect only after apply.
+
+- `network_bastion_hosts` - Paths ignored on the Bastion host.
+- `resources_resource_groups` - Paths ignored on the resource group.
+
+Type:
+
+```hcl
+object({
+    network_bastion_hosts     = optional(list(string), [])
+    resources_resource_groups = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_jump_vm_definition"></a> [jump\_vm\_definition](#input\_jump\_vm\_definition)
 
 Description: Configuration object for the Build VM to be created for managing the implementation services.
@@ -117,6 +137,44 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `network_bastion_hosts` - Bastion host resource type.
+- `resources_resource_groups` - Resource group resource type.
+
+Type:
+
+```hcl
+object({
+    network_bastion_hosts     = optional(string, "Microsoft.Network/bastionHosts@2024-05-01")
+    resources_resource_groups = optional(string, "Microsoft.Resources/resourceGroups@2024-11-01")
+  })
+```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration applied to every supported AzAPI resource declared by this module.
+
+- `error_message_regex` - Regular expressions matching errors that should be retried.
+- `interval_seconds` - Initial interval in seconds between retries.
+- `max_interval_seconds` - Maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `null`
+
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: Map of tags to be assigned to all resources created by this module.
@@ -124,6 +182,28 @@ Description: Map of tags to be assigned to all resources created by this module.
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Default per-operation timeouts applied to every supported AzAPI resource declared by this module.
+
+- `create` - Timeout for create operations.
+- `read` - Timeout for read operations.
+- `update` - Timeout for update operations.
+- `delete` - Timeout for delete operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/example_hub_vnet/locals.tf
+++ b/modules/example_hub_vnet/locals.tf
@@ -93,7 +93,7 @@ locals {
     }
   }
   region_zones        = local.region_zones_lookup != null ? local.region_zones_lookup : []
-  region_zones_lookup = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azurerm_resource_group.this.location) || (lower(region.display_name) == lower(azurerm_resource_group.this.location)))][0].zones
+  region_zones_lookup = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(azapi_resource.this.location) || (lower(region.display_name) == lower(azapi_resource.this.location)))][0].zones
   subnets = {
     AzureBastionSubnet = {
       enabled          = true

--- a/modules/example_hub_vnet/main.tf
+++ b/modules/example_hub_vnet/main.tf
@@ -1,4 +1,7 @@
 
+# AzAPI issue #981 can resolve CLI credentials instead of the configured provider identity.
+# Remove this exception when https://github.com/Azure/terraform-provider-azapi/issues/981 is fixed.
+# tflint-ignore: provider_azurerm_disallowed
 data "azurerm_client_config" "current" {}
 
 module "avm_utl_regions" {
@@ -12,10 +15,26 @@ resource "random_string" "name_suffix" {
   upper   = false
 }
 
-resource "azurerm_resource_group" "this" {
-  location = var.location
-  name     = var.resource_group_name
-  tags     = var.tags
+resource "azapi_resource" "this" {
+  type      = var.resource_types.resources_resource_groups
+  name      = var.resource_group_name
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  location  = var.location
+  tags      = var.tags
+
+  ignore_body_changes    = length(var.ignore_body_changes.resources_resource_groups) > 0 ? var.ignore_body_changes.resources_resource_groups : null
+  response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
+  }
 }
 
 #Create Hub Vnet (Subnets: AzureBastionSubnet, BuildVM subnet, Private Resolver Subnet?)
@@ -23,8 +42,8 @@ module "ai_lz_vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
   version = "=0.16.0"
 
-  location         = azurerm_resource_group.this.location
-  parent_id        = azurerm_resource_group.this.id
+  location         = azapi_resource.this.location
+  parent_id        = azapi_resource.this.id
   address_space    = [var.vnet_definition.address_space]
   enable_telemetry = var.enable_telemetry
   name             = local.vnet_name
@@ -35,9 +54,9 @@ module "natgateway" {
   source  = "Azure/avm-res-network-natgateway/azurerm"
   version = "0.2.1"
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.nat_gateway_name
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   enable_telemetry    = true
   public_ips = {
     public_ip_1 = {
@@ -50,23 +69,52 @@ module "bastion_pip" {
   source  = "Azure/avm-res-network-publicipaddress/azurerm"
   version = "0.2.0"
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = "${local.bastion_name}-pip"
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
   zones               = local.region_zones
 }
 
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this.location
-  name                = local.bastion_name
-  resource_group_name = azurerm_resource_group.this.name
-  tags                = var.tags
+resource "azapi_resource" "bastion" {
+  type      = var.resource_types.network_bastion_hosts
+  name      = local.bastion_name
+  parent_id = azapi_resource.this.id
+  location  = azapi_resource.this.location
+  tags      = var.tags
+  body = {
+    sku = {
+      name = "Basic"
+    }
+    properties = {
+      ipConfigurations = [
+        {
+          name = "${local.bastion_name}-ipconf"
+          properties = {
+            publicIPAddress = {
+              id = module.bastion_pip.resource_id
+            }
+            subnet = {
+              id = module.ai_lz_vnet.subnets["AzureBastionSubnet"].resource_id
+            }
+          }
+        }
+      ]
+    }
+  }
 
-  ip_configuration {
-    name                 = "${local.bastion_name}-ipconf"
-    public_ip_address_id = module.bastion_pip.resource_id
-    subnet_id            = module.ai_lz_vnet.subnets["AzureBastionSubnet"].resource_id
+  ignore_body_changes    = length(var.ignore_body_changes.network_bastion_hosts) > 0 ? var.ignore_body_changes.network_bastion_hosts : null
+  response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      read   = timeouts.value.read
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+    }
   }
 }
 
@@ -75,9 +123,9 @@ module "fw_pip" {
   source  = "Azure/avm-res-network-publicipaddress/azurerm"
   version = "0.2.0"
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = "${local.firewall_name}-pip"
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
   zones               = local.region_zones
 }
@@ -88,9 +136,9 @@ module "firewall" {
 
   firewall_sku_name   = "AZFW_VNet"
   firewall_sku_tier   = "Standard"
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = local.firewall_name
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   diagnostic_settings = {
     to_law = {
       name                  = "sendToLogAnalytics-fw-${random_string.name_suffix.result}"
@@ -114,9 +162,9 @@ module "firewall_policy" {
   source  = "Azure/avm-res-network-firewallpolicy/azurerm"
   version = "0.3.3"
 
-  location            = azurerm_resource_group.this.location
+  location            = azapi_resource.this.location
   name                = "${local.firewall_name}-policy"
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   enable_telemetry    = var.enable_telemetry
 }
 
@@ -135,9 +183,9 @@ module "log_analytics_workspace" {
   source  = "Azure/avm-res-operationalinsights-workspace/azurerm"
   version = "0.4.2"
 
-  location                                  = azurerm_resource_group.this.location
+  location                                  = azapi_resource.this.location
   name                                      = local.log_analytics_workspace_name
-  resource_group_name                       = azurerm_resource_group.this.name
+  resource_group_name                       = azapi_resource.this.name
   enable_telemetry                          = var.enable_telemetry
   log_analytics_workspace_retention_in_days = 30
   log_analytics_workspace_sku               = "PerGB2018"
@@ -147,9 +195,9 @@ module "private_resolver" {
   source  = "Azure/avm-res-network-dnsresolver/azurerm"
   version = "0.8.0"
 
-  location                    = azurerm_resource_group.this.location
+  location                    = azapi_resource.this.location
   name                        = "example-resolver"
-  resource_group_name         = azurerm_resource_group.this.name
+  resource_group_name         = azapi_resource.this.name
   virtual_network_resource_id = module.ai_lz_vnet.resource_id
   inbound_endpoints = {
     "inbound1" = {
@@ -165,7 +213,7 @@ module "private_dns_zones" {
   for_each = local.private_dns_zones
 
   domain_name      = each.value.name
-  parent_id        = azurerm_resource_group.this.id
+  parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
   virtual_network_links = {
     alz_vnet_link = {
@@ -186,7 +234,7 @@ module "jumpvm" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
   version = "0.20.0"
 
-  location = azurerm_resource_group.this.location
+  location = azapi_resource.this.location
   name     = local.jump_vm_name
   network_interfaces = {
     network_interface_1 = {
@@ -199,7 +247,7 @@ module "jumpvm" {
       }
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
+  resource_group_name = azapi_resource.this.name
   zone                = length(local.region_zones) > 0 ? random_integer.zone_index.result : null
   account_credentials = {
     key_vault_configuration = {
@@ -217,9 +265,9 @@ module "avm_res_keyvault_vault" {
   source  = "Azure/avm-res-keyvault-vault/azurerm"
   version = "=0.10.2"
 
-  location                    = azurerm_resource_group.this.location
+  location                    = azapi_resource.this.location
   name                        = local.kv_name
-  resource_group_name         = azurerm_resource_group.this.name
+  resource_group_name         = azapi_resource.this.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   enabled_for_disk_encryption = true
   network_acls = {

--- a/modules/example_hub_vnet/moved.tf
+++ b/modules/example_hub_vnet/moved.tf
@@ -1,0 +1,9 @@
+moved {
+  from = azurerm_resource_group.this
+  to   = azapi_resource.this
+}
+
+moved {
+  from = azurerm_bastion_host.bastion
+  to   = azapi_resource.bastion
+}

--- a/modules/example_hub_vnet/outputs.tf
+++ b/modules/example_hub_vnet/outputs.tf
@@ -10,7 +10,7 @@ output "firewall_ip_address" {
 
 output "resource_group_resource_id" {
   description = "The resource ID of the resource group where the hub virtual network is deployed"
-  value       = azurerm_resource_group.this.id
+  value       = azapi_resource.this.id
 }
 
 output "resource_id" {

--- a/modules/example_hub_vnet/terraform.tf
+++ b/modules/example_hub_vnet/terraform.tf
@@ -2,9 +2,14 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.12"
+    }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -16,5 +21,3 @@ terraform {
     }
   }
 }
-
-

--- a/modules/example_hub_vnet/variables.tf
+++ b/modules/example_hub_vnet/variables.tf
@@ -85,3 +85,67 @@ Map of tags to be assigned to all resources created by this module.
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
 DESCRIPTION
 }
+
+variable "resource_types" {
+  type = object({
+    network_bastion_hosts     = optional(string, "Microsoft.Network/bastionHosts@2024-05-01")
+    resources_resource_groups = optional(string, "Microsoft.Resources/resourceGroups@2024-11-01")
+  })
+  default     = {}
+  nullable    = false
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `network_bastion_hosts` - Bastion host resource type.
+- `resources_resource_groups` - Resource group resource type.
+DESCRIPTION
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Retry configuration applied to every supported AzAPI resource declared by this module.
+
+- `error_message_regex` - Regular expressions matching errors that should be retried.
+- `interval_seconds` - Initial interval in seconds between retries.
+- `max_interval_seconds` - Maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Default per-operation timeouts applied to every supported AzAPI resource declared by this module.
+
+- `create` - Timeout for create operations.
+- `read` - Timeout for read operations.
+- `update` - Timeout for update operations.
+- `delete` - Timeout for delete operations.
+DESCRIPTION
+}
+
+variable "ignore_body_changes" {
+  type = object({
+    network_bastion_hosts     = optional(list(string), [])
+    resources_resource_groups = optional(list(string), [])
+  })
+  default     = {}
+  nullable    = false
+  description = <<DESCRIPTION
+Body-relative dot-notation paths to ignore for each AzAPI resource. Ignored configuration is not sent to Azure, and changes to these paths take effect only after apply.
+
+- `network_bastion_hosts` - Paths ignored on the Bastion host.
+- `resources_resource_groups` - Paths ignored on the resource group.
+DESCRIPTION
+}

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = azurerm_resource_group.this
+  to   = azapi_resource.this
+}
+
+moved {
+  from = azurerm_network_security_rule.this
+  to   = azapi_resource.network_security_rule
+}
+
+moved {
+  from = azurerm_virtual_hub_connection.this
+  to   = azapi_resource.virtual_hub_connection
+}
+
+moved {
+  from = azurerm_role_assignment.deployment_user_kv_admin
+  to   = azapi_resource.deployment_user_kv_admin
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,8 +4,9 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.12"
     }
+    # tflint-ignore: provider_azurerm_disallowed
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,35 @@ If set to true, the module will deploy resources and connect to a platform landi
 DESCRIPTION
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    apimanagement_service_apis                           = optional(list(string), [])
+    apimanagement_service_apis_operations                = optional(list(string), [])
+    apimanagement_service_apis_policies                  = optional(list(string), [])
+    apimanagement_service_backends                       = optional(list(string), [])
+    authorization_role_assignments                       = optional(list(string), [])
+    bing_accounts                                        = optional(list(string), [])
+    network_network_security_groups_security_rules       = optional(list(string), [])
+    network_virtual_hubs_hub_virtual_network_connections = optional(list(string), [])
+    resources_resource_groups                            = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative dot-notation paths to ignore for each AzAPI resource. Ignored configuration is not sent to Azure, and changes to these paths take effect only after apply.
+
+- `apimanagement_service_apis` - Paths ignored on API Management APIs.
+- `apimanagement_service_apis_operations` - Paths ignored on API Management API operations.
+- `apimanagement_service_apis_policies` - Paths ignored on API Management API policies.
+- `apimanagement_service_backends` - Paths ignored on API Management backends.
+- `authorization_role_assignments` - Paths ignored on role assignments.
+- `bing_accounts` - Paths ignored on Bing accounts.
+- `network_network_security_groups_security_rules` - Paths ignored on network security rules.
+- `network_virtual_hubs_hub_virtual_network_connections` - Paths ignored on virtual hub connections.
+- `resources_resource_groups` - Paths ignored on resource groups.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "name_prefix" {
   type        = string
   default     = null
@@ -57,6 +86,53 @@ DESCRIPTION
   }
 }
 
+variable "resource_types" {
+  type = object({
+    apimanagement_service_apis                                   = optional(string, "Microsoft.ApiManagement/service/apis@2024-05-01")
+    apimanagement_service_apis_operations                        = optional(string, "Microsoft.ApiManagement/service/apis/operations@2024-05-01")
+    apimanagement_service_apis_policies                          = optional(string, "Microsoft.ApiManagement/service/apis/policies@2024-05-01")
+    apimanagement_service_backends                               = optional(string, "Microsoft.ApiManagement/service/backends@2024-05-01")
+    authorization_role_assignments                               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    bing_accounts                                                = optional(string, "Microsoft.Bing/accounts@2025-05-01-preview")
+    cognitiveservices_locations_resource_groups_deleted_accounts = optional(string, "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2021-04-30")
+    network_network_security_groups_security_rules               = optional(string, "Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01")
+    network_virtual_hubs_hub_virtual_network_connections         = optional(string, "Microsoft.Network/virtualHubs/hubVirtualNetworkConnections@2024-05-01")
+    resources_resource_groups                                    = optional(string, "Microsoft.Resources/resourceGroups@2024-11-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `apimanagement_service_apis` - API Management API resource type.
+- `apimanagement_service_apis_operations` - API Management API operation resource type.
+- `apimanagement_service_apis_policies` - API Management API policy resource type.
+- `apimanagement_service_backends` - API Management backend resource type.
+- `authorization_role_assignments` - Role assignment resource type.
+- `bing_accounts` - Bing account resource type.
+- `cognitiveservices_locations_resource_groups_deleted_accounts` - Deleted Cognitive Services account action type.
+- `network_network_security_groups_security_rules` - Network security rule resource type.
+- `network_virtual_hubs_hub_virtual_network_connections` - Virtual hub connection resource type.
+- `resources_resource_groups` - Resource group resource type.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Retry configuration applied to every supported AzAPI resource declared by this module.
+
+- `error_message_regex` - Regular expressions matching errors that should be retried.
+- `interval_seconds` - Initial interval in seconds between retries.
+- `max_interval_seconds` - Maximum interval in seconds between retries.
+DESCRIPTION
+}
+
 variable "tags" {
   type        = map(string)
   default     = null
@@ -64,5 +140,23 @@ variable "tags" {
 Map of tags to be assigned to all resources created by this module.
 
 Tags are key-value pairs that help organize and manage Azure resources. These tags will be applied to all resources created by the module, enabling consistent resource governance, cost tracking, and operational management across the AI/ML landing zone infrastructure.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Default per-operation timeouts applied to every supported AzAPI resource declared by this module.
+
+- `create` - Timeout for create operations.
+- `read` - Timeout for read operations.
+- `update` - Timeout for update operations.
+- `delete` - Timeout for delete operations.
 DESCRIPTION
 }


### PR DESCRIPTION
## Why this PR exists

The repository's current `main` cannot pass the complete AVM pull-request validation. A baseline audit found **27 pre-existing lint failures**; **21** are direct AzureRM control-plane resources rejected by the repository's AVM lint policy.

That matters because every parity proposal — [#162](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/162), [#163](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/163), [#164](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/164), [#166](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/166), [#167](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/167), and [#170](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/170) — inherits the same failures. Without a separate baseline, reviewers cannot tell whether a failed AVM check was introduced by the PR under review or already existed in `main`.

This PR fixes that shared foundation once. It does **not** add a parity capability.

## Why AzAPI 2.12

We considered three ways to handle the inherited debt:

1. **Ignore or broadly suppress the failures:** rejected because it would hide real compliance problems.
2. **Replace every direct resource with an AVM Resource Module:** not selected because it would add unnecessary module dependencies and abstraction for small, existing resource bodies.
3. **Move the direct resources to AzAPI:** selected because it satisfies the repository's [AVM policy](https://azure.github.io/Azure-Verified-Modules/spec/TFFR3/) while keeping the implementation focused and close to the Azure Resource Manager API.

AzAPI `~> 2.12` is used because the [AVM Terraform provider requirement](https://azure.github.io/Azure-Verified-Modules/spec/TFFR3/) requires that floor and this version supports the cross-provider state conversion needed to move existing AzureRM-managed resources without intentionally deleting and recreating them. The migration follows the [Microsoft AzureRM-to-AzAPI guidance](https://learn.microsoft.com/azure/developer/terraform/how-to-migrate-between-azurerm-and-azapi).

In simple terms: **AzAPI is the implementation choice; a clean, trustworthy AVM baseline is the reason for the change.**

## What changes

- Migrates the root resource group, NSG rules, virtual hub connection, and Key Vault deployment-principal role assignment from direct AzureRM resources to AzAPI.
- Migrates example resource groups and the local example-hub resource group and Bastion host.
- Adds the standard AVM AzAPI interfaces for resource types, retries, timeouts, response exports, and ignored body paths.
- Preserves AzureRM replacement behavior for immutable role-assignment principal/role changes and virtual-hub remote-VNet changes.
- Keeps published AVM module sources ending in `/azurerm`; those are Registry module namespaces, not direct AzureRM resources.

## What does not change

The intended Azure topology, resource names, inputs, defaults, outputs, identities, RBAC, and networking behavior remain the same. This PR is intended to change Terraform's provider/state representation, not the deployed architecture.

## State and upgrade safety

Declarative cross-provider `moved` blocks preserve the existing resource IDs and Terraform collection instances:

- `azurerm_resource_group.this` -> `azapi_resource.this`
- `azurerm_network_security_rule.this` -> `azapi_resource.network_security_rule`
- `azurerm_virtual_hub_connection.this` -> `azapi_resource.virtual_hub_connection`
- `azurerm_role_assignment.deployment_user_kv_admin` -> `azapi_resource.deployment_user_kv_admin`

The historical Key Vault role-assignment GUID is retained through state conversion. `ignore_changes = [name]` prevents replacement of an AzureRM-generated GUID, while principal and role changes still trigger replacement. New deployments use a deterministic UUIDv5.

This is proposed as a breaking pre-GA `v0.6.0` baseline because the provider-state conversion is one-way: AzureRM cannot perform the reverse AzAPI-to-AzureRM state move. The migration guide therefore requires a state backup, a reviewed no-destroy/no-replace upgrade plan, an apply, and a no-change second plan.

## Narrow AzureRM exception

The only direct AzureRM data source retained is `data.azurerm_client_config.current`, with block-specific lint exclusions. This preserves the configured service-principal, managed-identity, or aliased-provider identity while [AzAPI issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) can return Azure CLI context instead. No direct `azurerm_*` resource remains. The exception should be removed when [AzAPI issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) is fixed.

## Validation completed

- All six Terraform scopes initialized and validated successfully; remaining warnings are deprecations inside downloaded AVM dependencies.
- `avm lint`: passed across all six scopes.
- `avm pre-commit -Ecosystem terraform`: **5/5 stages passed**.
- Clean-worktree `avm pr-check`: **8/8 stages passed** — sync, format, transform, lint, policy, convention, Terraform validation, and documentation.
- No blanket lint suppression was added.

## Remaining merge and release gates

- Run the Azure-backed upgrade test: deploy released `v0.5.1`, switch to this `v0.6.0` candidate, require no destroy/replacement, apply, require a no-change second plan, and destroy through the migrated implementation.
- Run the upstream release-branch managed AVM CI flow.
- Obtain normal maintainer review and approval.

## Review decision requested

Please confirm that:

- fixing the inherited AVM debt in one prerequisite PR is the right approach;
- the state-preserving AzAPI migration is safe;
- the narrow [AzAPI issue #981](https://github.com/Azure/terraform-provider-azapi/issues/981) exception is acceptable;
- `v0.6.0` is the appropriate pre-GA version for this one-way state migration.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit checks](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks)

The unchecked pipeline item reflects the remaining upstream managed CI and Azure-backed upgrade gates described above.